### PR TITLE
feat(impersonate): Optimize reuse of impersonate configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,12 +199,17 @@ path = "examples/simple.rs"
 [[example]]
 name = "impersonate"
 path = "examples/impersonate.rs"
-required-features = ["blocking", "socks", "cookies", "zstd", "hickory-dns"]
+required-features = ["blocking", "socks", "zstd", "hickory-dns"]
+
+[[example]]
+name = "psk_impersonate"
+path = "examples/psk_impersonate.rs"
+required-features = ["blocking", "socks", "zstd", "hickory-dns"]
 
 [[example]]
 name = "set_proxies"
 path = "examples/set_proxies.rs"
-required-features = ["blocking", "socks", "cookies", "zstd", "hickory-dns", "socks"]
+required-features = ["blocking", "socks", "zstd", "hickory-dns", "socks"]
 
 [[example]]
 name = "set_local_address"

--- a/examples/impersonate.rs
+++ b/examples/impersonate.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 async fn main() -> Result<(), Box<dyn Error>> {
     // Build a client to mimic Edge127
     let client = rquest::Client::builder()
-        .impersonate(Impersonate::Safari17_5)
+        .impersonate(Impersonate::Edge127)
         .enable_ech_grease()
         .permute_extensions()
         .cookie_store(true)

--- a/examples/impersonate.rs
+++ b/examples/impersonate.rs
@@ -6,13 +6,16 @@ use std::error::Error;
 async fn main() -> Result<(), Box<dyn Error>> {
     // Build a client to mimic Edge127
     let client = rquest::Client::builder()
-        .impersonate(Impersonate::Edge127)
+        .impersonate(Impersonate::Safari17_5)
         .enable_ech_grease()
         .permute_extensions()
         .cookie_store(true)
         .build()?;
 
     // Use the API you're already familiar with
+    let resp = client.get("https://tls.peet.ws/api/all").send().await?;
+    println!("{}", resp.text().await?);
+
     let resp = client.get("https://tls.peet.ws/api/all").send().await?;
     println!("{}", resp.text().await?);
 

--- a/examples/psk_impersonate.rs
+++ b/examples/psk_impersonate.rs
@@ -12,6 +12,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
 
     // Use the API you're already familiar with
+    let _ = client.get("https://tls.peet.ws/api/all").send().await?;
+
+    // Now, let's impersonate a PSK
     let resp = client.get("https://tls.peet.ws/api/all").send().await?;
     println!("{}", resp.text().await?);
 

--- a/examples/set_proxies.rs
+++ b/examples/set_proxies.rs
@@ -8,7 +8,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .impersonate(Impersonate::Chrome126)
         .enable_ech_grease()
         .permute_extensions()
-        .cookie_store(true)
         .build()?;
 
     let resp = client.get("https://api.ip.sb/ip").send().await?;

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -95,7 +95,7 @@ struct Config {
     #[cfg(feature = "__tls")]
     tls_info: bool,
     #[cfg(feature = "__tls")]
-    tls: TlsBackend,
+    tls: Option<TlsBackend>,
     http_version_pref: HttpVersionPref,
     http09_responses: bool,
     http1_title_case_headers: bool,
@@ -175,7 +175,7 @@ impl ClientBuilder {
                 #[cfg(feature = "__tls")]
                 tls_info: false,
                 #[cfg(feature = "__tls")]
-                tls: TlsBackend::default(),
+                tls: None,
                 http_version_pref: HttpVersionPref::All,
                 http09_responses: false,
                 http1_title_case_headers: false,
@@ -291,7 +291,7 @@ impl ClientBuilder {
             http.set_connect_timeout(config.connect_timeout);
 
             #[cfg(feature = "__tls")]
-            match config.tls {
+            match config.tls.unwrap_or_default() {
                 #[cfg(feature = "__boring")]
                 TlsBackend::BoringTls(tls) => Connector::new_boring_tls(
                     http,
@@ -1178,7 +1178,7 @@ impl ClientBuilder {
         mut self,
         connector: crate::impersonate::BoringTlsConnector,
     ) -> ClientBuilder {
-        self.config.tls = TlsBackend::BoringTls(connector);
+        self.config.tls = Some(TlsBackend::BoringTls(connector));
         self
     }
 

--- a/src/impersonate/chrome/mod.rs
+++ b/src/impersonate/chrome/mod.rs
@@ -1,8 +1,7 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, Error, SslConnector, SslConnectorBuilder, SslCurve, SslMethod,
-    SslVersion,
+use boring::{
+    error::ErrorStack,
+    ssl::{CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion},
 };
-
 pub mod v100;
 pub mod v101;
 pub mod v104;
@@ -50,42 +49,26 @@ const CIPHER_LIST: [&str; 15] = [
     "TLS_RSA_WITH_AES_256_CBC_SHA",
 ];
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls_client())?;
 
-    builder.set_default_verify_paths().unwrap();
+    builder.set_default_verify_paths()?;
 
     builder.set_grease_enabled(true);
 
     builder.enable_ocsp_stapling();
 
-    builder.set_cipher_list(&CIPHER_LIST.join(":")).unwrap();
+    builder.set_cipher_list(&CIPHER_LIST.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":"))?;
 
     builder.enable_signed_cert_timestamps();
 
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
+    builder.add_cert_compression_alg(CertCompressionAlgorithm::Brotli)?;
 
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
+    builder.set_min_proto_version(Some(SslVersion::TLS1_2))?;
 
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
+    builder.set_max_proto_version(Some(SslVersion::TLS1_3))?;
 
-    builder
-}
-
-fn configure_curves_ssl(builder: &mut SslConnectorBuilder) -> Result<(), Error> {
-    builder.set_curves(&[
-        SslCurve::X25519_KYBER768_DRAFT00,
-        SslCurve::X25519,
-        SslCurve::SECP256R1,
-        SslCurve::SECP384R1,
-    ])?;
-    Ok(())
+    Ok(builder)
 }

--- a/src/impersonate/chrome/v100.rs
+++ b/src/impersonate/chrome/v100.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
 use http::{
@@ -11,7 +9,7 @@ use http::{
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v101.rs
+++ b/src/impersonate/chrome/v101.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
 use http::{
@@ -11,7 +9,7 @@ use http::{
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v104.rs
+++ b/src/impersonate/chrome/v104.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
 use http::{
@@ -11,7 +9,7 @@ use http::{
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v105.rs
+++ b/src/impersonate/chrome/v105.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
 use http::{
@@ -11,7 +9,7 @@ use http::{
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v106.rs
+++ b/src/impersonate/chrome/v106.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
 use http::{
@@ -11,7 +9,7 @@ use http::{
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v107.rs
+++ b/src/impersonate/chrome/v107.rs
@@ -6,11 +6,10 @@ use http::{
     },
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v108.rs
+++ b/src/impersonate/chrome/v108.rs
@@ -6,11 +6,10 @@ use http::{
     },
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v109.rs
+++ b/src/impersonate/chrome/v109.rs
@@ -6,11 +6,10 @@ use http::{
     },
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v114.rs
+++ b/src/impersonate/chrome/v114.rs
@@ -6,11 +6,10 @@ use http::{
     },
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v116.rs
+++ b/src/impersonate/chrome/v116.rs
@@ -4,11 +4,10 @@ use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v117.rs
+++ b/src/impersonate/chrome/v117.rs
@@ -4,11 +4,10 @@ use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v118.rs
+++ b/src/impersonate/chrome/v118.rs
@@ -6,11 +6,10 @@ use http::{
     },
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v119.rs
+++ b/src/impersonate/chrome/v119.rs
@@ -7,11 +7,10 @@ use http::{
     },
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v120.rs
+++ b/src/impersonate/chrome/v120.rs
@@ -7,11 +7,10 @@ use http::{
     },
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v123.rs
+++ b/src/impersonate/chrome/v123.rs
@@ -4,11 +4,10 @@ use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v124.rs
+++ b/src/impersonate/chrome/v124.rs
@@ -1,18 +1,18 @@
-use super::{configure_curves_ssl, ssl_builder};
+use super::ssl_builder;
+use crate::impersonate::curves::configure_chrome_new_curves;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(|| {
-            let mut builder = ssl_builder();
-            configure_curves_ssl(&mut builder).expect("Failed to configure curves SSL");
-            builder
-        })),
+        tls_connector: BoringTlsConnector::new(|| {
+            let mut builder = ssl_builder()?;
+            configure_chrome_new_curves(&mut builder)?;
+            Ok(builder)
+        }),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/chrome/v126.rs
+++ b/src/impersonate/chrome/v126.rs
@@ -1,18 +1,18 @@
-use super::{configure_curves_ssl, ssl_builder};
+use super::ssl_builder;
+use crate::impersonate::curves::configure_chrome_new_curves;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(|| {
-            let mut builder = ssl_builder();
-            configure_curves_ssl(&mut builder).expect("Failed to configure curves SSL");
-            builder
-        })),
+        tls_connector: BoringTlsConnector::new(|| {
+            let mut builder = ssl_builder()?;
+            configure_chrome_new_curves(&mut builder)?;
+            Ok(builder)
+        }),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/curves.rs
+++ b/src/impersonate/curves.rs
@@ -1,0 +1,12 @@
+use boring::error::ErrorStack;
+use boring::ssl::{SslConnectorBuilder, SslCurve};
+
+/// Configure chrome to use the curves. (Chrome 123+)
+pub fn configure_chrome_new_curves(builder: &mut SslConnectorBuilder) -> Result<(), ErrorStack> {
+    builder.set_curves(&[
+        SslCurve::X25519_KYBER768_DRAFT00,
+        SslCurve::X25519,
+        SslCurve::SECP256R1,
+        SslCurve::SECP384R1,
+    ])
+}

--- a/src/impersonate/edge/edge101.rs
+++ b/src/impersonate/edge/edge101.rs
@@ -4,11 +4,10 @@ use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/edge/edge122.rs
+++ b/src/impersonate/edge/edge122.rs
@@ -4,11 +4,10 @@ use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/edge/edge127.rs
+++ b/src/impersonate/edge/edge127.rs
@@ -1,18 +1,19 @@
-use super::{configure_curves_ssl, ssl_builder};
-use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
+use super::ssl_builder;
+use crate::impersonate::{
+    curves::configure_chrome_new_curves, BoringTlsConnector, Http2Data, ImpersonateSettings,
+};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(|| {
-            let mut builder = ssl_builder();
-            configure_curves_ssl(&mut builder).expect("Failed to configure curves SSL");
-            builder
-        })),
+        tls_connector: BoringTlsConnector::new(|| {
+            let mut builder = ssl_builder()?;
+            configure_chrome_new_curves(&mut builder)?;
+            Ok(builder)
+        }),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/edge/edge99.rs
+++ b/src/impersonate/edge/edge99.rs
@@ -4,11 +4,10 @@ use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/impersonate/edge/mod.rs
+++ b/src/impersonate/edge/mod.rs
@@ -1,6 +1,6 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, Error, SslConnector, SslConnectorBuilder, SslCurve, SslMethod,
-    SslVersion,
+use boring::{
+    error::ErrorStack,
+    ssl::{CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion},
 };
 pub mod edge101;
 pub mod edge122;
@@ -36,42 +36,26 @@ const CIPHER_LIST: [&str; 15] = [
     "TLS_RSA_WITH_AES_256_CBC_SHA",
 ];
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls_client())?;
 
-    builder.set_default_verify_paths().unwrap();
+    builder.set_default_verify_paths()?;
 
     builder.set_grease_enabled(true);
 
     builder.enable_ocsp_stapling();
 
-    builder.set_cipher_list(&CIPHER_LIST.join(":")).unwrap();
+    builder.set_cipher_list(&CIPHER_LIST.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":"))?;
 
     builder.enable_signed_cert_timestamps();
 
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
+    builder.add_cert_compression_alg(CertCompressionAlgorithm::Brotli)?;
 
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
+    builder.set_min_proto_version(Some(SslVersion::TLS1_2))?;
 
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
+    builder.set_max_proto_version(Some(SslVersion::TLS1_3))?;
 
-    builder
-}
-
-fn configure_curves_ssl(builder: &mut SslConnectorBuilder) -> Result<(), Error> {
-    builder.set_curves(&[
-        SslCurve::X25519_KYBER768_DRAFT00,
-        SslCurve::X25519,
-        SslCurve::SECP256R1,
-        SslCurve::SECP384R1,
-    ])?;
-    Ok(())
+    Ok(builder)
 }

--- a/src/impersonate/mod.rs
+++ b/src/impersonate/mod.rs
@@ -1,4 +1,5 @@
 mod chrome;
+mod curves;
 mod edge;
 mod okhttp;
 pub mod profile;
@@ -16,49 +17,45 @@ use profile::ClientProfile;
 pub use profile::Impersonate;
 use std::sync::Arc;
 
+type Builder = dyn Fn() -> Result<SslConnectorBuilder, ErrorStack> + Send + Sync;
+
 /// A wrapper around a `SslConnectorBuilder` that allows for additional settings.
 #[derive(Clone)]
 pub struct BoringTlsConnector {
-    /// The inner `SslConnectorBuilder` function.
-    inner: Arc<dyn Fn() -> SslConnectorBuilder + Send + Sync>,
+    /// The inner `` function.
+    builder: Arc<Builder>,
     /// The cached `HttpsConnector`.
     session: Arc<Mutex<SessionCache>>,
 }
 
 impl BoringTlsConnector {
     /// Create a new `BoringTlsConnector` with the given function.
-    pub fn new(inner: Arc<dyn Fn() -> SslConnectorBuilder + Send + Sync>) -> BoringTlsConnector {
+    pub fn new<F>(builder: F) -> BoringTlsConnector
+    where
+        F: Fn() -> Result<SslConnectorBuilder, ErrorStack> + Send + Sync + 'static,
+    {
         Self {
-            inner,
+            builder: Arc::new(builder),
             session: Arc::new(Mutex::new(SessionCache::new())),
         }
     }
 
     /// Create a new `HttpsConnector` with the settings from the `ImpersonateContext`.
+    #[inline]
     pub(crate) async fn create_https_connector(
         &self,
         context: &ImpersonateContext,
         http: HttpConnector,
     ) -> Result<HttpsConnector<HttpConnector>, ErrorStack> {
-        let mut builder = (self.inner)();
-        alpn_and_cert_settings(context, &mut builder);
-
-        let psk_extension = match context.impersonate {
-            Impersonate::Chrome117
-            | Impersonate::Chrome120
-            | Impersonate::Chrome123
-            | Impersonate::Chrome124
-            | Impersonate::Chrome126
-            | Impersonate::Edge122
-            | Impersonate::Edge127 => true,
-            _ => false,
-        };
-
-        self.create_connector(context, http, builder, psk_extension)
+        let mut builder = (self.builder)()?;
+        set_alpn_proto(&mut builder, context.h2);
+        set_cert_verification(&mut builder, context.certs_verification);
+        self.create_connector(context, http, builder)
     }
 
     /// Create a new `SslConnector` with the settings from the `ImpersonateContext`.
     #[cfg(feature = "socks")]
+    #[inline]
     pub(crate) async fn create_connector_configuration(
         &self,
         context: &ImpersonateContext,
@@ -68,7 +65,7 @@ impl BoringTlsConnector {
     ) -> Result<ConnectConfiguration, ErrorStack> {
         let connector = self.create_https_connector(context, http).await?;
         let mut conf = connector.configure_and_setup(uri, host)?;
-        add_application_settings(&mut conf, context);
+        set_add_application_settings(&mut conf, context);
         Ok(conf)
     }
 
@@ -78,64 +75,85 @@ impl BoringTlsConnector {
         context: &ImpersonateContext,
         http: HttpConnector,
         builder: SslConnectorBuilder,
-        psk: bool,
     ) -> Result<HttpsConnector<HttpConnector>, ErrorStack> {
-        let mut http = if psk {
+        let psk_extension = matches!(
+            context.impersonate,
+            Impersonate::Chrome117
+                | Impersonate::Chrome120
+                | Impersonate::Chrome123
+                | Impersonate::Chrome124
+                | Impersonate::Chrome126
+                | Impersonate::Edge122
+                | Impersonate::Edge127
+        );
+
+        let mut http = if psk_extension {
             HttpsConnector::with_connector_and_cache(http, builder, self.session.clone())?
         } else {
             HttpsConnector::with_connector(http, builder)?
         };
-        let context = context.clone();
-        http.set_callback(move |conf, _| Ok(add_application_settings(conf, &context)));
+
+        set_callback(&mut http, context.clone());
         Ok(http)
     }
 }
 
+/// Configure the callback for the given `HttpsConnector`.
+fn set_callback(http: &mut HttpsConnector<HttpConnector>, context: ImpersonateContext) {
+    http.set_callback(move |conf, _| Ok(set_add_application_settings(conf, &context)));
+}
+
 /// Configure the ALPN and certificate settings for the given `SslConnectorBuilder`.
-fn alpn_and_cert_settings(context: &ImpersonateContext, builder: &mut SslConnectorBuilder) {
-    if context.h2 {
+fn set_alpn_proto(builder: &mut SslConnectorBuilder, h2: bool) {
+    if h2 {
         builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
     } else {
         builder.set_alpn_protos(b"\x08http/1.1").unwrap();
     }
+}
 
-    if !context.certs_verification {
+/// Configure the certificate verification for the given `SslConnectorBuilder`.
+fn set_cert_verification(builder: &mut SslConnectorBuilder, certs_verification: bool) {
+    if !certs_verification {
         builder.set_verify(boring::ssl::SslVerifyMode::NONE);
     }
 }
 
 /// Add application settings to the given `ConnectConfiguration`.
-fn add_application_settings(conf: &mut ConnectConfiguration, ctx: &ImpersonateContext) {
-    use foreign_types::ForeignTypeRef;
+fn set_add_application_settings(conf: &mut ConnectConfiguration, ctx: &ImpersonateContext) {
     match ctx.impersonate.profile() {
         ClientProfile::Chrome | ClientProfile::Edge => {
-            // Enable random TLS extensions
-            if ctx.permute_extensions {
-                unsafe {
-                    boring_sys::SSL_set_permute_extensions(conf.as_ptr(), 1);
-                }
-            }
-
-            // Enable ECH grease
-            if ctx.enable_ech_grease {
-                unsafe { boring_sys::SSL_set_enable_ech_grease(conf.as_ptr(), 1) }
-            }
-
-            if ctx.h2 {
-                const ALPN_H2: &str = "h2";
-                const ALPN_H2_LENGTH: usize = 2;
-                unsafe {
-                    boring_sys::SSL_add_application_settings(
-                        conf.as_ptr(),
-                        ALPN_H2.as_ptr(),
-                        ALPN_H2_LENGTH,
-                        std::ptr::null(),
-                        0,
-                    );
-                };
-            }
+            configure_tls_extensions(conf, ctx);
         }
         _ => {}
+    }
+}
+
+/// Configure the TLS extensions for the given `ConnectConfiguration`.
+fn configure_tls_extensions(conf: &mut ConnectConfiguration, ctx: &ImpersonateContext) {
+    use foreign_types::ForeignTypeRef;
+    if ctx.permute_extensions {
+        unsafe {
+            boring_sys::SSL_set_permute_extensions(conf.as_ptr(), 1);
+        }
+    }
+
+    if ctx.enable_ech_grease {
+        unsafe { boring_sys::SSL_set_enable_ech_grease(conf.as_ptr(), 1) }
+    }
+
+    if ctx.h2 {
+        const ALPN_H2: &str = "h2";
+        const ALPN_H2_LENGTH: usize = 2;
+        unsafe {
+            boring_sys::SSL_add_application_settings(
+                conf.as_ptr(),
+                ALPN_H2.as_ptr(),
+                ALPN_H2_LENGTH,
+                std::ptr::null(),
+                0,
+            );
+        };
     }
 }
 

--- a/src/impersonate/okhttp/mod.rs
+++ b/src/impersonate/okhttp/mod.rs
@@ -1,3 +1,8 @@
+use boring::{
+    error::ErrorStack,
+    ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion},
+};
+
 pub mod okhttp3_11;
 pub mod okhttp3_13;
 pub mod okhttp3_14;
@@ -17,3 +22,21 @@ const SIGALGS_LIST: [&str; 9] = [
     "rsa_pkcs1_sha512",
     "rsa_pkcs1_sha1",
 ];
+
+fn base_ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls_client())?;
+
+    builder.set_default_verify_paths()?;
+
+    builder.enable_ocsp_stapling();
+
+    builder.set_curves(&[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1])?;
+
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":"))?;
+
+    builder.set_min_proto_version(Some(SslVersion::TLS1_2))?;
+
+    builder.set_max_proto_version(Some(SslVersion::TLS1_3))?;
+
+    Ok(builder)
+}

--- a/src/impersonate/okhttp/okhttp3_11.rs
+++ b/src/impersonate/okhttp/okhttp3_11.rs
@@ -1,9 +1,6 @@
 use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::{
-    error::ErrorStack,
-    ssl::SslConnectorBuilder,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,

--- a/src/impersonate/okhttp/okhttp3_11.rs
+++ b/src/impersonate/okhttp/okhttp3_11.rs
@@ -1,15 +1,17 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion};
+use boring::{
+    error::ErrorStack,
+    ssl::SslConnectorBuilder,
+};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),
@@ -24,16 +26,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.enable_ocsp_stapling();
-
-    builder
-        .set_curves(&[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1])
-        .unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
@@ -51,19 +45,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/okhttp/okhttp3_13.rs
+++ b/src/impersonate/okhttp/okhttp3_13.rs
@@ -1,9 +1,6 @@
 use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::{
-    error::ErrorStack,
-    ssl::SslConnectorBuilder,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,

--- a/src/impersonate/okhttp/okhttp3_13.rs
+++ b/src/impersonate/okhttp/okhttp3_13.rs
@@ -1,15 +1,17 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion};
+use boring::{
+    error::ErrorStack,
+    ssl::SslConnectorBuilder,
+};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),
@@ -24,16 +26,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.enable_ocsp_stapling();
-
-    builder
-        .set_curves(&[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1])
-        .unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -56,19 +50,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/okhttp/okhttp3_14.rs
+++ b/src/impersonate/okhttp/okhttp3_14.rs
@@ -1,15 +1,19 @@
-use super::SIGALGS_LIST;
-use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion};
+use super::base_ssl_builder;
+use crate::impersonate::{
+    BoringTlsConnector, Http2Data, ImpersonateSettings,
+};
+use boring::{
+    error::ErrorStack,
+    ssl::SslConnectorBuilder,
+};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),
@@ -24,16 +28,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.enable_ocsp_stapling();
-
-    builder
-        .set_curves(&[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1])
-        .unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -54,19 +50,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/okhttp/okhttp3_14.rs
+++ b/src/impersonate/okhttp/okhttp3_14.rs
@@ -1,11 +1,6 @@
 use super::base_ssl_builder;
-use crate::impersonate::{
-    BoringTlsConnector, Http2Data, ImpersonateSettings,
-};
-use boring::{
-    error::ErrorStack,
-    ssl::SslConnectorBuilder,
-};
+use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,

--- a/src/impersonate/okhttp/okhttp3_9.rs
+++ b/src/impersonate/okhttp/okhttp3_9.rs
@@ -1,9 +1,6 @@
 use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::{
-    error::ErrorStack,
-    ssl::SslConnectorBuilder,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,

--- a/src/impersonate/okhttp/okhttp3_9.rs
+++ b/src/impersonate/okhttp/okhttp3_9.rs
@@ -1,15 +1,17 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion};
+use boring::{
+    error::ErrorStack,
+    ssl::SslConnectorBuilder,
+};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),
@@ -24,16 +26,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.enable_ocsp_stapling();
-
-    builder
-        .set_curves(&[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1])
-        .unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
@@ -53,19 +47,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/okhttp/okhttp4_10.rs
+++ b/src/impersonate/okhttp/okhttp4_10.rs
@@ -1,9 +1,6 @@
 use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::{
-    error::ErrorStack,
-    ssl::SslConnectorBuilder,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,

--- a/src/impersonate/okhttp/okhttp4_10.rs
+++ b/src/impersonate/okhttp/okhttp4_10.rs
@@ -1,15 +1,17 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion};
+use boring::{
+    error::ErrorStack,
+    ssl::SslConnectorBuilder,
+};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),
@@ -24,16 +26,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.enable_ocsp_stapling();
-
-    builder
-        .set_curves(&[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1])
-        .unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -54,19 +48,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/okhttp/okhttp4_9.rs
+++ b/src/impersonate/okhttp/okhttp4_9.rs
@@ -1,9 +1,6 @@
 use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::{
-    error::ErrorStack,
-    ssl::SslConnectorBuilder,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,

--- a/src/impersonate/okhttp/okhttp4_9.rs
+++ b/src/impersonate/okhttp/okhttp4_9.rs
@@ -1,15 +1,17 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion};
+use boring::{
+    error::ErrorStack,
+    ssl::SslConnectorBuilder,
+};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),
@@ -24,16 +26,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.enable_ocsp_stapling();
-
-    builder
-        .set_curves(&[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1])
-        .unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -53,19 +47,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_AES_256_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/okhttp/okhttp5.rs
+++ b/src/impersonate/okhttp/okhttp5.rs
@@ -1,9 +1,6 @@
 use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::{
-    error::ErrorStack,
-    ssl::SslConnectorBuilder,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,

--- a/src/impersonate/okhttp/okhttp5.rs
+++ b/src/impersonate/okhttp/okhttp5.rs
@@ -1,15 +1,17 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion};
+use boring::{
+    error::ErrorStack,
+    ssl::SslConnectorBuilder,
+};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),
@@ -24,16 +26,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.enable_ocsp_stapling();
-
-    builder
-        .set_curves(&[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1])
-        .unwrap();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -54,19 +48,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/safari/mod.rs
+++ b/src/impersonate/safari/mod.rs
@@ -10,6 +10,14 @@ pub mod safari_ios_16_5;
 pub mod safari_ios_17_2;
 pub mod safari_ios_17_4_1;
 
+use boring::{
+    error::ErrorStack,
+    ssl::{
+        CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod,
+        SslOptions, SslVersion,
+    },
+};
+
 const SIGALGS_LIST: [&str; 11] = [
     "ecdsa_secp256r1_sha256",
     "rsa_pss_rsae_sha256",
@@ -23,3 +31,32 @@ const SIGALGS_LIST: [&str; 11] = [
     "rsa_pkcs1_sha512",
     "rsa_pkcs1_sha1",
 ];
+
+fn base_ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls_client())?;
+
+    builder.set_default_verify_paths()?;
+
+    builder.set_options(SslOptions::NO_TICKET);
+
+    builder.set_grease_enabled(true);
+
+    builder.enable_ocsp_stapling();
+
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":"))?;
+
+    builder.set_curves(&[
+        SslCurve::X25519,
+        SslCurve::SECP256R1,
+        SslCurve::SECP384R1,
+        SslCurve::SECP521R1,
+    ])?;
+
+    builder.enable_signed_cert_timestamps();
+
+    builder.add_cert_compression_alg(CertCompressionAlgorithm::Zlib)?;
+
+    builder.set_min_proto_version(Some(SslVersion::TLS1))?;
+
+    Ok(builder)
+}

--- a/src/impersonate/safari/safari15_3.rs
+++ b/src/impersonate/safari/safari15_3.rs
@@ -1,15 +1,14 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslOptions, SslVersion};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),
@@ -24,16 +23,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_options(SslOptions::NO_TICKET);
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -64,26 +55,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_curves(&[
-            SslCurve::X25519,
-            SslCurve::SECP256R1,
-            SslCurve::SECP384R1,
-            SslCurve::SECP521R1,
-        ])
-        .unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/safari/safari15_5.rs
+++ b/src/impersonate/safari/safari15_5.rs
@@ -1,18 +1,14 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslOptions,
-    SslVersion,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),
@@ -27,16 +23,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_options(SslOptions::NO_TICKET);
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -61,30 +49,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_curves(&[
-            SslCurve::X25519,
-            SslCurve::SECP256R1,
-            SslCurve::SECP384R1,
-            SslCurve::SECP521R1,
-        ])
-        .unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Zlib)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/safari/safari15_6_1.rs
+++ b/src/impersonate/safari/safari15_6_1.rs
@@ -1,18 +1,14 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslOptions,
-    SslVersion,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),
@@ -27,16 +23,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_options(SslOptions::NO_TICKET);
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -61,30 +49,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_curves(&[
-            SslCurve::X25519,
-            SslCurve::SECP256R1,
-            SslCurve::SECP384R1,
-            SslCurve::SECP521R1,
-        ])
-        .unwrap();
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Zlib)
-        .unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/safari/safari_ios_16_5.rs
+++ b/src/impersonate/safari/safari_ios_16_5.rs
@@ -1,18 +1,14 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslOptions,
-    SslVersion,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(2097152),
             initial_connection_window_size: Some(10551295),
@@ -27,16 +23,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_options(SslOptions::NO_TICKET);
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -61,30 +49,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_curves(&[
-            SslCurve::X25519,
-            SslCurve::SECP256R1,
-            SslCurve::SECP384R1,
-            SslCurve::SECP521R1,
-        ])
-        .unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Zlib)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/safari/safari_ios_17_2.rs
+++ b/src/impersonate/safari/safari_ios_17_2.rs
@@ -1,18 +1,14 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslOptions,
-    SslVersion,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(2097152),
             initial_connection_window_size: Some(10551295),
@@ -27,16 +23,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_options(SslOptions::NO_TICKET);
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -61,30 +49,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_curves(&[
-            SslCurve::X25519,
-            SslCurve::SECP256R1,
-            SslCurve::SECP384R1,
-            SslCurve::SECP521R1,
-        ])
-        .unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Zlib)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/safari/safari_ios_17_4_1.rs
+++ b/src/impersonate/safari/safari_ios_17_4_1.rs
@@ -1,18 +1,14 @@
-use super::SIGALGS_LIST;
+use super::base_ssl_builder;
 use crate::impersonate::{BoringTlsConnector, Http2Data, ImpersonateSettings};
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslOptions,
-    SslVersion,
-};
+use boring::{error::ErrorStack, ssl::SslConnectorBuilder};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
 };
-use std::sync::Arc;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
-        tls_connector: BoringTlsConnector::new(Arc::new(ssl_builder)),
+        tls_connector: BoringTlsConnector::new(ssl_builder),
         http2: Http2Data {
             initial_stream_window_size: Some(2097152),
             initial_connection_window_size: Some(10551295),
@@ -27,16 +23,8 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     }
 }
 
-fn ssl_builder() -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_options(SslOptions::NO_TICKET);
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
+fn ssl_builder() -> Result<SslConnectorBuilder, ErrorStack> {
+    let mut builder = base_ssl_builder()?;
 
     let cipher_list = [
         "TLS_AES_128_GCM_SHA256",
@@ -61,30 +49,9 @@ fn ssl_builder() -> SslConnectorBuilder {
         "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
     ];
 
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+    builder.set_cipher_list(&cipher_list.join(":"))?;
 
-    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
-
-    builder
-        .set_curves(&[
-            SslCurve::X25519,
-            SslCurve::SECP256R1,
-            SslCurve::SECP384R1,
-            SslCurve::SECP521R1,
-        ])
-        .unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Zlib)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1))
-        .unwrap();
-
-    builder
+    Ok(builder)
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -7,10 +7,7 @@
 //! - Various parts of TLS can also be configured or even disabled on the
 //!   `ClientBuilder`.
 
-use boring::ssl::SslConnectorBuilder;
 use std::fmt;
-#[cfg(feature = "__boring")]
-use std::sync::Arc;
 #[cfg(feature = "__boring")]
 use crate::impersonate::BoringTlsConnector;
 
@@ -63,11 +60,7 @@ impl Default for TlsBackend {
         #[cfg(feature = "__boring")]
         {
             use boring::ssl::{SslConnector, SslMethod};
-
-            fn create_builder() -> SslConnectorBuilder {
-                SslConnector::builder(SslMethod::tls()).unwrap()
-            }
-            TlsBackend::BoringTls(BoringTlsConnector::new(Arc::new(create_builder)))
+            TlsBackend::BoringTls(BoringTlsConnector::new(|| SslConnector::builder(SslMethod::tls())))
         }
         #[cfg(not(feature = "__boring"))]
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new example for `psk_impersonate` showcasing asynchronous HTTP client configurations.
	- Streamlined feature requirements by removing unnecessary options, enhancing clarity for users.

- **Bug Fixes**
	- Removed redundant code in the `impersonate` example, eliminating duplicate API requests.
	- Disabled cookie storage in multiple examples, simplifying session management.

- **Documentation**
	- Updated examples to reflect new configurations and clarify usage scenarios for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->