### PR TITLE
[impersonate] add `chrome_127`

### DIFF
--- a/src/impersonate/chrome/mod.rs
+++ b/src/impersonate/chrome/mod.rs
@@ -15,6 +15,7 @@ pub mod v120;
 pub mod v123;
 pub mod v124;
 pub mod v126;
+pub mod v127;
 
 const CIPHER_LIST: [&str; 15] = [
     "TLS_AES_128_GCM_SHA256",

--- a/src/impersonate/chrome/v127.rs
+++ b/src/impersonate/chrome/v127.rs
@@ -1,0 +1,54 @@
+use super::CIPHER_LIST;
+use crate::impersonate::extension::{ChromeExtension, Extension, SslExtension};
+use crate::impersonate::profile::{Http2Settings, ImpersonateSettings};
+use crate::impersonate::BoringTlsConnector;
+use http::{
+    header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
+    HeaderMap, HeaderValue,
+};
+
+pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
+    ImpersonateSettings {
+        tls_connector: BoringTlsConnector::new(|| {
+            ChromeExtension::builder()?
+                .configure_cipher_list(&CIPHER_LIST)?
+                .configure_chrome_new_curves()
+        }),
+        http2: Http2Settings {
+            initial_stream_window_size: Some(6291456),
+            initial_connection_window_size: Some(15728640),
+            max_concurrent_streams: None,
+            max_header_list_size: Some(262144),
+            header_table_size: Some(65536),
+            enable_push: Some(false),
+        },
+        headers: create_headers(headers),
+        gzip: true,
+        brotli: true,
+    }
+}
+
+fn create_headers(mut headers: HeaderMap) -> HeaderMap {
+    headers.insert(
+        "sec-ch-ua",
+        HeaderValue::from_static(
+            "\"Not)A;Brand\";v=\"99\", \"Google Chrome\";v=\"127\", \"Chromium\";v=\"127\"",
+        ),
+    );
+    headers.insert("sec-ch-ua-mobile", HeaderValue::from_static("?0"));
+    headers.insert("sec-ch-ua-platform", HeaderValue::from_static("\"macOS\""));
+    headers.insert(UPGRADE_INSECURE_REQUESTS, HeaderValue::from_static("1"));
+    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36"));
+    headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"));
+    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert("sec-fetch-user", HeaderValue::from_static("?1"));
+    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
+    headers.insert(
+        ACCEPT_ENCODING,
+        HeaderValue::from_static("gzip, deflate, br, zstd"),
+    );
+    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
+
+    headers
+}

--- a/src/impersonate/mod.rs
+++ b/src/impersonate/mod.rs
@@ -75,6 +75,7 @@ impl BoringTlsConnector {
                 | Impersonate::Chrome123
                 | Impersonate::Chrome124
                 | Impersonate::Chrome126
+                | Impersonate::Chrome127
                 | Impersonate::Edge122
                 | Impersonate::Edge127
         );

--- a/src/impersonate/profile.rs
+++ b/src/impersonate/profile.rs
@@ -66,6 +66,7 @@ fn get_settings(ver: Impersonate) -> ImpersonateSettings {
         Impersonate::Chrome123 => chrome::v123::get_settings,
         Impersonate::Chrome124 => chrome::v124::get_settings,
         Impersonate::Chrome126 => chrome::v126::get_settings,
+        Impersonate::Chrome127 => chrome::v127::get_settings,
 
         Impersonate::SafariIos17_2 => safari::safari_ios_17_2::get_settings,
         Impersonate::SafariIos17_4_1 => safari::safari_ios_17_4_1::get_settings,
@@ -114,6 +115,7 @@ pub enum Impersonate {
     Chrome123,
     Chrome124,
     Chrome126,
+    Chrome127,
     SafariIos17_2,
     SafariIos17_4_1,
     SafariIos16_5,
@@ -167,6 +169,7 @@ impl FromStr for Impersonate {
             "chrome_123" => Ok(Impersonate::Chrome123),
             "chrome_124" => Ok(Impersonate::Chrome124),
             "chrome_126" => Ok(Impersonate::Chrome126),
+            "chrome_127" => Ok(Impersonate::Chrome127),
 
             "safari_ios_17.2" => Ok(Impersonate::SafariIos17_2),
             "safari_ios_17.4.1" => Ok(Impersonate::SafariIos17_4_1),
@@ -217,7 +220,8 @@ impl Impersonate {
             | Impersonate::Chrome120
             | Impersonate::Chrome123
             | Impersonate::Chrome124
-            | Impersonate::Chrome126 => ClientProfile::Chrome,
+            | Impersonate::Chrome126
+            | Impersonate::Chrome127 => ClientProfile::Chrome,
 
             Impersonate::SafariIos17_2
             | Impersonate::SafariIos16_5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new module, `v127`, enhancing the modular structure for future functionalities.
	- Added functionality for managing HTTP settings specific to Chrome browser behavior.
	- Expanded the `Impersonate` options to include `Chrome127`, broadening browser impersonation capabilities.

- **Updates**
	- Improved the `get_settings` function to accommodate new Chrome settings.
	- Enhanced string parsing to recognize the new `Chrome127` variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->