### PR TITLE
feat(impersonate): Add `Safari17_0` impersonate

### DIFF
--- a/src/impersonate/profile.rs
+++ b/src/impersonate/profile.rs
@@ -76,6 +76,7 @@ fn get_settings(ver: Impersonate) -> ImpersonateSettings {
         Impersonate::Safari15_6_1 => safari::safari15_6_1::get_settings,
         Impersonate::Safari16 => safari::safari16::get_settings,
         Impersonate::Safari16_5 => safari::safari16_5::get_settings,
+        Impersonate::Safari17_0 => safari::safari17_0::get_settings,
         Impersonate::Safari17_2_1 => safari::safari17_2_1::get_settings,
         Impersonate::Safari17_4_1 => safari::safari17_4_1::get_settings,
         Impersonate::Safari17_5 => safari::safari17_5::get_settings,
@@ -124,6 +125,7 @@ pub enum Impersonate {
     Safari15_6_1,
     Safari16,
     Safari16_5,
+    Safari17_0,
     Safari17_2_1,
     Safari17_4_1,
     Safari17_5,
@@ -179,6 +181,7 @@ impl FromStr for Impersonate {
             "safari_16" => Ok(Impersonate::Safari16),
             "safari_16.5" => Ok(Impersonate::Safari16_5),
             "safari_ios_16.5" => Ok(Impersonate::SafariIos16_5),
+            "safari_17.0" => Ok(Impersonate::Safari17_0),
             "safari_17.2.1" => Ok(Impersonate::Safari17_2_1),
             "safari_17.4.1" => Ok(Impersonate::Safari17_4_1),
             "safari_17.5" => Ok(Impersonate::Safari17_5),
@@ -231,6 +234,7 @@ impl Impersonate {
             | Impersonate::Safari15_6_1
             | Impersonate::Safari16
             | Impersonate::Safari16_5
+            | Impersonate::Safari17_0
             | Impersonate::Safari17_2_1
             | Impersonate::Safari17_4_1
             | Impersonate::Safari17_5 => ClientProfile::Safari,

--- a/src/impersonate/safari/mod.rs
+++ b/src/impersonate/safari/mod.rs
@@ -9,6 +9,7 @@ pub mod safari17_5;
 pub mod safari_ios_16_5;
 pub mod safari_ios_17_2;
 pub mod safari_ios_17_4_1;
+pub mod safari17_0;
 
 const OLD_CIPHER_LIST: [&str; 26] = [
     "TLS_AES_128_GCM_SHA256",

--- a/src/impersonate/safari/safari15_3.rs
+++ b/src/impersonate/safari/safari15_3.rs
@@ -33,10 +33,13 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
     headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static("en-US,en;q=0.9"),
+    );
+    headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
-    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-us"));
-
+    
     headers
 }

--- a/src/impersonate/safari/safari15_5.rs
+++ b/src/impersonate/safari/safari15_5.rs
@@ -34,7 +34,7 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
     );
     headers.insert(
         ACCEPT_LANGUAGE,
-        HeaderValue::from_static("de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"),
+        HeaderValue::from_static("en-US,en;q=0.9"),
     );
     headers.insert(
         ACCEPT_ENCODING,

--- a/src/impersonate/safari/safari15_6_1.rs
+++ b/src/impersonate/safari/safari15_6_1.rs
@@ -31,7 +31,7 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
     headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
     headers.insert(
         ACCEPT_LANGUAGE,
-        HeaderValue::from_static("de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"),
+        HeaderValue::from_static("en-US,en;q=0.9"),
     );
     headers.insert(
         ACCEPT_ENCODING,

--- a/src/impersonate/safari/safari16.rs
+++ b/src/impersonate/safari/safari16.rs
@@ -29,7 +29,10 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {
     headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15"));
     headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
-    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-us"));
+    headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static("en-US,en;q=0.9"),
+    );
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),

--- a/src/impersonate/safari/safari16_5.rs
+++ b/src/impersonate/safari/safari16_5.rs
@@ -35,7 +35,7 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
     );
     headers.insert(
         ACCEPT_LANGUAGE,
-        HeaderValue::from_static("de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"),
+        HeaderValue::from_static("en-US,en;q=0.9"),
     );
     headers.insert(
         ACCEPT_ENCODING,

--- a/src/impersonate/safari/safari17_0.rs
+++ b/src/impersonate/safari/safari17_0.rs
@@ -13,12 +13,12 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)
         }),
         http2: Http2Settings {
-            initial_stream_window_size: Some(2097152),
+            initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),
             max_concurrent_streams: Some(100),
             max_header_list_size: None,
             header_table_size: None,
-            enable_push: None,
+            enable_push: Some(false),
         },
         headers: create_headers(headers),
         gzip: true,
@@ -32,17 +32,17 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
     headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
-    headers.insert(
-        ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US,en;q=0.9"),
-    );
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1"));
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
+    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"));
+    headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static("en-US,en;q=0.9"),
+    );
+    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
 
     headers
 }

--- a/src/impersonate/safari/safari17_2_1.rs
+++ b/src/impersonate/safari/safari17_2_1.rs
@@ -31,18 +31,18 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
         ACCEPT,
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
-    headers.insert("sec-fetch-site", HeaderValue::from_static("same-origin"));
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
-    headers.insert(
-        ACCEPT_LANGUAGE,
-        HeaderValue::from_static("de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"),
-    );
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15"));
+    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
+    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15"));
+    headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static("en-US,en;q=0.9"),
+    );
+    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
 
     headers
 }

--- a/src/impersonate/safari/safari17_4_1.rs
+++ b/src/impersonate/safari/safari17_4_1.rs
@@ -31,18 +31,17 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
         ACCEPT,
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
-    headers.insert("sec-fetch-site", HeaderValue::from_static("same-origin"));
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
-    headers.insert(
-        ACCEPT_LANGUAGE,
-        HeaderValue::from_static("de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"),
-    );
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"));
+    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
-
+    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"));
+    headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static("en-US,en;q=0.9"),
+    );
+    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
     headers
 }

--- a/src/impersonate/safari/safari17_5.rs
+++ b/src/impersonate/safari/safari17_5.rs
@@ -40,7 +40,7 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
     headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15"));
     headers.insert(
         ACCEPT_LANGUAGE,
-        HeaderValue::from_static("de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"),
+        HeaderValue::from_static("en-US,en;q=0.9"),
     );
     headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
 

--- a/src/impersonate/safari/safari_ios_17_2.rs
+++ b/src/impersonate/safari/safari_ios_17_2.rs
@@ -32,17 +32,16 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
     headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
-    headers.insert(
-        ACCEPT_LANGUAGE,
-        HeaderValue::from_static("de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"),
-    );
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1"));
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
-
+    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1"));
+    headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static("en-US,en;q=0.9"),
+    );
+    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
     headers
 }

--- a/src/impersonate/safari/safari_ios_17_4_1.rs
+++ b/src/impersonate/safari/safari_ios_17_4_1.rs
@@ -32,17 +32,16 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
     headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
-    headers.insert(
-        ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US;q=0.8,en;q=0.7"),
-    );
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (iPad; CPU OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1"));
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
-
+    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (iPad; CPU OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1"));
+    headers.insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static("en-US,en;q=0.9"),
+    );
+    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
     headers
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Safari 17.0 in the impersonation module, enhancing profile management for this browser version.
	- Introduced refined HTTP settings and headers specific to Safari 17.0, improving compatibility with web services.

- **Bug Fixes**
	- Updated `ACCEPT_LANGUAGE` headers across multiple Safari versions to ensure accurate language preferences in requests.

- **Refactor**
	- Streamlined header configurations in several Safari versions to focus primarily on English language settings, simplifying content negotiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->