### PR TITLE
refactor: Enabled `accept-encoding` will be determined by the `feature`

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -467,6 +467,7 @@ impl ClientBuilder {
         };
         self
     }
+
     /// Sets the default headers for every request.
     ///
     /// # Example
@@ -518,6 +519,7 @@ impl ClientBuilder {
         self
     }
 
+    /// Replace the default headers for every request.
     #[cfg(feature = "__browser_common")]
     pub(crate) fn replace_default_headers(mut self, headers: HeaderMap) -> ClientBuilder {
         self.config.headers = headers;
@@ -1078,7 +1080,6 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn tls_built_in_root_certs(mut self, tls_built_in_root_certs: bool) -> ClientBuilder {
@@ -1133,7 +1134,6 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn min_tls_version(mut self, version: tls::Version) -> ClientBuilder {
@@ -1154,7 +1154,6 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn max_tls_version(mut self, version: tls::Version) -> ClientBuilder {
@@ -1181,7 +1180,6 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn tls_info(mut self, tls_info: bool) -> ClientBuilder {

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1072,25 +1072,6 @@ impl ClientBuilder {
 
     // TLS options
 
-    /// Add a custom root certificate.
-    ///
-    /// This can be used to connect to a server that has a self-signed
-    /// certificate for example.
-    ///
-    /// # Optional
-    ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
-    /// feature to be enabled.
-    #[cfg(feature = "__tls")]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "default-tls",
-            feature = "native-tls",
-            feature = "rustls-tls"
-        )))
-    )]
-
     /// Controls the use of built-in/preloaded certificates during certificate validation.
     ///
     /// Defaults to `true` -- built-in system certs will be used.
@@ -1100,14 +1081,6 @@ impl ClientBuilder {
     /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "default-tls",
-            feature = "native-tls",
-            feature = "rustls-tls"
-        )))
-    )]
     pub fn tls_built_in_root_certs(mut self, tls_built_in_root_certs: bool) -> ClientBuilder {
         self.config.tls_built_in_root_certs = tls_built_in_root_certs;
         self
@@ -1163,14 +1136,6 @@ impl ClientBuilder {
     /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "default-tls",
-            feature = "native-tls",
-            feature = "rustls-tls"
-        )))
-    )]
     pub fn min_tls_version(mut self, version: tls::Version) -> ClientBuilder {
         self.config.min_tls_version = Some(version);
         self
@@ -1192,14 +1157,6 @@ impl ClientBuilder {
     /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "default-tls",
-            feature = "native-tls",
-            feature = "rustls-tls"
-        )))
-    )]
     pub fn max_tls_version(mut self, version: tls::Version) -> ClientBuilder {
         self.config.max_tls_version = Some(version);
         self

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -634,7 +634,6 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn tls_built_in_root_certs(self, tls_built_in_root_certs: bool) -> ClientBuilder {
@@ -678,7 +677,6 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn min_tls_version(self, version: tls::Version) -> ClientBuilder {
@@ -698,7 +696,6 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn max_tls_version(self, version: tls::Version) -> ClientBuilder {
@@ -709,7 +706,6 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn tls_info(self, tls_info: bool) -> ClientBuilder {
@@ -768,8 +764,6 @@ impl ClientBuilder {
     pub fn resolve_to_addrs(self, domain: &str, addrs: &[SocketAddr]) -> ClientBuilder {
         self.with_inner(|inner| inner.resolve_to_addrs(domain, addrs))
     }
-
-    // private
 
     fn with_inner<F>(mut self, func: F) -> ClientBuilder
     where

--- a/src/tls/chrome/v100.rs
+++ b/src/tls/chrome/v100.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v101.rs
+++ b/src/tls/chrome/v101.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v104.rs
+++ b/src/tls/chrome/v104.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v105.rs
+++ b/src/tls/chrome/v105.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v106.rs
+++ b/src/tls/chrome/v106.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v107.rs
+++ b/src/tls/chrome/v107.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v108.rs
+++ b/src/tls/chrome/v108.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v109.rs
+++ b/src/tls/chrome/v109.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v114.rs
+++ b/src/tls/chrome/v114.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v116.rs
+++ b/src/tls/chrome/v116.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v117.rs
+++ b/src/tls/chrome/v117.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v118.rs
+++ b/src/tls/chrome/v118.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v119.rs
+++ b/src/tls/chrome/v119.rs
@@ -24,9 +24,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v120.rs
+++ b/src/tls/chrome/v120.rs
@@ -24,9 +24,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/chrome/v123.rs
+++ b/src/tls/chrome/v123.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: true,
     }
 }
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/tls/chrome/v124.rs
+++ b/src/tls/chrome/v124.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: true,
     }
 }
 

--- a/src/tls/chrome/v126.rs
+++ b/src/tls/chrome/v126.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: true,
     }
 }
 

--- a/src/tls/chrome/v127.rs
+++ b/src/tls/chrome/v127.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: true,
     }
 }
 

--- a/src/tls/edge/edge101.rs
+++ b/src/tls/edge/edge101.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/edge/edge122.rs
+++ b/src/tls/edge/edge122.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/edge/edge127.rs
+++ b/src/tls/edge/edge127.rs
@@ -23,9 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: true,
     }
 }
 

--- a/src/tls/edge/edge99.rs
+++ b/src/tls/edge/edge99.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/okhttp/okhttp3_11.rs
+++ b/src/tls/okhttp/okhttp3_11.rs
@@ -34,9 +34,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/okhttp/okhttp3_13.rs
+++ b/src/tls/okhttp/okhttp3_13.rs
@@ -39,9 +39,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/okhttp/okhttp3_14.rs
+++ b/src/tls/okhttp/okhttp3_14.rs
@@ -37,9 +37,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/okhttp/okhttp3_9.rs
+++ b/src/tls/okhttp/okhttp3_9.rs
@@ -36,9 +36,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/okhttp/okhttp4_10.rs
+++ b/src/tls/okhttp/okhttp4_10.rs
@@ -37,9 +37,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/okhttp/okhttp4_9.rs
+++ b/src/tls/okhttp/okhttp4_9.rs
@@ -36,9 +36,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/okhttp/okhttp5.rs
+++ b/src/tls/okhttp/okhttp5.rs
@@ -37,9 +37,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/profile.rs
+++ b/src/tls/profile.rs
@@ -21,8 +21,6 @@ pub(crate) fn configure_impersonate(ver: Impersonate, builder: ClientBuilder) ->
         .http2_header_table_size(settings.http2.header_table_size)
         .http2_enable_push(settings.http2.enable_push)
         .replace_default_headers(settings.headers)
-        .brotli(settings.brotli)
-        .gzip(settings.gzip)
 }
 
 macro_rules! impersonate_match {
@@ -274,9 +272,6 @@ pub struct ImpersonateSettings {
     pub tls_connector: BoringTlsConnector,
     pub http2: Http2Settings,
     pub headers: HeaderMap,
-    pub gzip: bool,
-    pub brotli: bool,
-    pub zstd: bool,
 }
 
 /// HTTP/2 settings.

--- a/src/tls/safari/safari15_3.rs
+++ b/src/tls/safari/safari15_3.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari15_5.rs
+++ b/src/tls/safari/safari15_5.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari15_6_1.rs
+++ b/src/tls/safari/safari15_6_1.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari16.rs
+++ b/src/tls/safari/safari16.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari16_5.rs
+++ b/src/tls/safari/safari16_5.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari17_0.rs
+++ b/src/tls/safari/safari17_0.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari17_2_1.rs
+++ b/src/tls/safari/safari17_2_1.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari17_4_1.rs
+++ b/src/tls/safari/safari17_4_1.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari17_5.rs
+++ b/src/tls/safari/safari17_5.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari_ios_16_5.rs
+++ b/src/tls/safari/safari_ios_16_5.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: None,
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari_ios_17_2.rs
+++ b/src/tls/safari/safari_ios_17_2.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 

--- a/src/tls/safari/safari_ios_17_4_1.rs
+++ b/src/tls/safari/safari_ios_17_4_1.rs
@@ -21,9 +21,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
             enable_push: Some(false),
         },
         headers: create_headers(headers),
-        gzip: true,
-        brotli: true,
-        zstd: false,
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Simplified `ImpersonateSettings` by removing compression options: `gzip`, `brotli`, and `zstd`, leading to a more streamlined configuration process.

- **Bug Fixes**
    - Addressed potential issues related to outdated compression settings in existing implementations.

- **Documentation**
    - Removed documentation comments for several public methods in the `ClientBuilder`, which may impact user understanding of the optional features.
    
- **Refactor**
    - Updated multiple components to reflect the removal of compression fields from the `ImpersonateSettings` struct, enhancing code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->