### PR TITLE
revert(tls): Revert tls_built_in_root_certs option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rquest"
 version = "0.20.1"
-description = "An fast asynchronous Rust `Http`/`WebSocket` Client with `TLS`/`JA3`/`JA4`/`HTTP2` fingerprint impersonate"
+description = "An fast asynchronous Rust Http/WebSocket Client with TLS/JA3/JA4/HTTP2 fingerprint impersonate"
 keywords = ["http", "request", "client", "websocket", "ja3"]
 categories = ["web-programming::http-client"]
 repository = "https://github.com/0x676e67/rquest"

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -112,8 +112,6 @@ struct Config {
     dns_overrides: HashMap<String, Vec<SocketAddr>>,
     dns_resolver: Option<Arc<dyn Resolve>>,
     #[cfg(feature = "boring-tls")]
-    tls_built_in_root_certs: bool,
-    #[cfg(feature = "boring-tls")]
     tls_info: bool,
     #[cfg(feature = "boring-tls")]
     tls: TlsConnectorBuilder,
@@ -179,8 +177,6 @@ impl ClientBuilder {
                 https_only: false,
                 dns_overrides: HashMap::new(),
                 dns_resolver: None,
-                #[cfg(feature = "boring-tls")]
-                tls_built_in_root_certs: true,
                 #[cfg(feature = "boring-tls")]
                 tls_info: false,
                 #[cfg(feature = "boring-tls")]
@@ -1030,21 +1026,6 @@ impl ClientBuilder {
         D: Into<Option<Duration>>,
     {
         self.config.tcp_keepalive = val.into();
-        self
-    }
-
-    // TLS options
-
-    /// Controls the use of built-in/preloaded certificates during certificate validation.
-    ///
-    /// Defaults to `true` -- built-in system certs will be used.
-    ///
-    /// # Optional
-    ///
-    /// feature to be enabled.
-    #[cfg(feature = "boring-tls")]
-    pub fn tls_built_in_root_certs(mut self, tls_built_in_root_certs: bool) -> ClientBuilder {
-        self.config.tls_built_in_root_certs = tls_built_in_root_certs;
         self
     }
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -626,20 +626,6 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.tcp_keepalive(val))
     }
 
-    // TLS options
-
-    /// Controls the use of built-in system certificates during certificate validation.
-    ///
-    /// Defaults to `true` -- built-in system certs will be used.
-    ///
-    /// # Optional
-    ///
-    /// feature to be enabled.
-    #[cfg_attr(docsrs, doc(cfg(feature = "boring-tls")))]
-    pub fn tls_built_in_root_certs(self, tls_built_in_root_certs: bool) -> ClientBuilder {
-        self.with_inner(move |inner| inner.tls_built_in_root_certs(tls_built_in_root_certs))
-    }
-
     /// Controls the use of certificate validation.
     ///
     /// Defaults to `false`.

--- a/src/tls/extension.rs
+++ b/src/tls/extension.rs
@@ -1,15 +1,13 @@
 #![allow(missing_docs)]
 
+use super::Version;
+use crate::async_impl::client::HttpVersionPref;
 use boring::error::ErrorStack;
 use boring::ssl::{
     CertCompressionAlgorithm, ConnectConfiguration, SslConnector, SslConnectorBuilder, SslCurve,
     SslMethod, SslOptions, SslVersion,
 };
 use foreign_types::ForeignTypeRef;
-
-use crate::async_impl::client::HttpVersionPref;
-
-use super::Version;
 
 /// Extension trait for `SslConnector`.
 pub trait Extension {

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -36,18 +36,3 @@ async fn test_badssl_self_signed() {
 
     assert!(text.contains("<title>self-signed.badssl.com</title>"));
 }
-
-#[cfg(feature = "boring-tls")]
-#[tokio::test]
-async fn test_badssl_no_built_in_roots() {
-    let result = rquest::Client::builder()
-        .tls_built_in_root_certs(false)
-        .no_proxy()
-        .build()
-        .unwrap()
-        .get("https://untrusted-root.badssl.com/")
-        .send()
-        .await;
-
-    assert!(result.is_err());
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced readability of the package description by removing code formatting.
	
- **Bug Fixes**
	- Removed the `tls_built_in_root_certs` option from the ClientBuilder for both async and blocking clients, streamlining TLS configuration.

- **Tests**
	- Removed the `test_badssl_no_built_in_roots` test function, reflecting updated testing strategy for TLS configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->