### PR TITLE
deps(boring/hyper/h2): Migration patch crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ boring-tls = [
     "hyper-boring",
     "boring-sys",
     "foreign-types",
-    "antidote",
 ]
 
 # When enabled, disable using the cached SYS_PROXIES.
@@ -93,14 +92,14 @@ mime_guess = { version = "2.0", default-features = false, optional = true }
 
 encoding_rs = "0.8"
 http-body = "0.4.6"
-hyper = { package = "hyper_imp", version = "0.14", default-features = false, features = [
+hyper = { package = "hyper-patch", version = "0.14", default-features = false, features = [
     "tcp",
     "http1",
     "http2",
     "client",
     "runtime",
 ] }
-h2 = { package = "h2_imp", version = "0.5" }
+h2 = { package = "h2-patch", version = "0.5" }
 log = "0.4"
 mime = "0.3.17"
 percent-encoding = "2.3"
@@ -111,12 +110,11 @@ ipnet = "2.9.0"
 # Optional deps...
 
 ## boring-tls
-boring = { package = "boring-imp", version = "4", optional = true }
-boring-sys = { package = "boring-sys-imp", version = "4", optional = true }
-hyper-boring = { package = "hyper-boring-imp", version = "4", optional = true }
-tokio-boring = { package = "tokio-boring-imp", version = "4", optional = true }
+boring = { package = "boring-patch", version = "4", optional = true }
+boring-sys = { package = "boring-sys-patch", version = "4", optional = true }
+hyper-boring = { package = "hyper-boring-patch", version = "4", optional = true }
+tokio-boring = { package = "tokio-boring-patch", version = "4", optional = true }
 foreign-types = { version = "0.5.0", optional = true }
-antidote = { version = "1.0.0", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18", package = "cookie", optional = true }
@@ -150,7 +148,7 @@ system-configuration = "0.6.0"
 
 [dev-dependencies]
 env_logger = "0.10.0"
-hyper = { package = "hyper_imp", version = "0.14", default-features = false, features = [
+hyper = { package = "hyper-patch", version = "0.14", default-features = false, features = [
     "tcp",
     "stream",
     "http1",

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -18,13 +18,12 @@ pub(crate) use self::profile::connect_settings;
 use crate::async_impl::client::HttpVersionPref;
 use crate::connect::HttpConnector;
 use crate::tls::extension::{SslConnectExtension, SslExtension};
-use antidote::Mutex;
 use boring::ssl::{SslConnector, SslMethod};
 use boring::{
     error::ErrorStack,
     ssl::{ConnectConfiguration, SslConnectorBuilder},
 };
-use hyper_boring::{HttpsConnector, HttpsLayer, HttpsLayerSettings, SessionCache};
+use hyper_boring::{HttpsConnector, HttpsLayer, HttpsLayerSettings};
 use profile::ClientProfile;
 pub use profile::{ConnectSettings, Http2Settings, Impersonate};
 use std::any::Any;
@@ -34,9 +33,6 @@ use tokio::sync::OnceCell;
 
 /// Default session cache capacity.
 const DEFAULT_SESSION_CACHE_CAPACITY: usize = 8;
-
-/// A TLS session cache.
-type Session = Arc<Mutex<SessionCache>>;
 
 /// A TLS connector builder.
 type Builder = dyn Fn() -> Result<SslConnectorBuilder, ErrorStack> + Send + Sync + 'static;
@@ -168,9 +164,6 @@ impl TlsConnector {
                 builder,
                 HttpsLayerSettings::builder()
                     .session_cache_capacity(DEFAULT_SESSION_CACHE_CAPACITY)
-                    .session_cache(Session::new(Mutex::new(SessionCache::with_capacity(
-                        DEFAULT_SESSION_CACHE_CAPACITY,
-                    ))))
                     .build(),
             )
         } else {

--- a/src/tls/profile.rs
+++ b/src/tls/profile.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 use crate::tls::{chrome, edge, okhttp, safari};
-use h2::profile::AgentProfile;
 use http::HeaderMap;
+use hyper::AgentProfile;
 use std::{any::Any, fmt::Debug, str::FromStr, sync::Arc};
 
 macro_rules! impersonate_match {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated dependency references for several packages, enhancing clarity in package sourcing.
  
- **Bug Fixes**
  - Removed the `antidote` dependency to improve compatibility and project efficiency.

- **Refactor**
  - Simplified TLS session management by eliminating the `Mutex` dependency, leading to potentially better performance in TLS connections.
  
- **Documentation**
  - Adjusted import statements to leverage the `hyper` library for agent profile management, reflecting a change in underlying framework dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->