### PR TITLE
feat(tls): Add option to configure TLS server name indication (SNI)

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -121,8 +121,8 @@ impl ClientBuilder {
 
     /// Enable TLS pre_shared_key
     #[cfg_attr(docsrs, doc(cfg(feature = "boring-tls")))]
-    pub fn pre_shared_key(self, enable: bool) -> ClientBuilder {
-        self.with_inner(move |inner| inner.pre_shared_key(enable))
+    pub fn pre_shared_key(self) -> ClientBuilder {
+        self.with_inner(move |inner| inner.pre_shared_key())
     }
 
     // Higher-level options
@@ -671,9 +671,17 @@ impl ClientBuilder {
     /// will be trusted for use. This includes expired certificates. This
     /// introduces significant vulnerabilities, and should only be used
     /// as a last resort.
-    #[cfg_attr(docsrs, doc(cfg(feature = "boring-tls")))]
+    #[cfg(feature = "boring-tls")]
     pub fn danger_accept_invalid_certs(self, accept_invalid_certs: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.danger_accept_invalid_certs(accept_invalid_certs))
+    }
+
+    /// Controls the use of TLS server name indication.
+    ///
+    /// Defaults to `true`.
+    #[cfg(feature = "boring-tls")]
+    pub fn tls_sni(self, tls_sni: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.tls_sni(tls_sni))
     }
 
     /// Set the minimum required TLS version for connections.
@@ -690,7 +698,7 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// feature to be enabled.
-    #[cfg_attr(docsrs, doc(cfg(feature = "boring-tls")))]
+    #[cfg(feature = "boring-tls")]
     pub fn min_tls_version(self, version: tls::Version) -> ClientBuilder {
         self.with_inner(|inner| inner.min_tls_version(version))
     }
@@ -709,7 +717,7 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// feature to be enabled.
-    #[cfg_attr(docsrs, doc(cfg(feature = "boring-tls")))]
+    #[cfg(feature = "boring-tls")]
     pub fn max_tls_version(self, version: tls::Version) -> ClientBuilder {
         self.with_inner(|inner| inner.max_tls_version(version))
     }
@@ -719,7 +727,7 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// feature to be enabled.
-    #[cfg_attr(docsrs, doc(cfg(feature = "boring-tls")))]
+    #[cfg(feature = "boring-tls")]
     pub fn tls_info(self, tls_info: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.tls_info(tls_info))
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "boring-tls")]
-use crate::tls::{connector, TlsConnector};
+use crate::tls::{connector, BoringTlsConnector};
 #[cfg(feature = "boring-tls")]
 use http::header::HeaderValue;
 use http::uri::{Authority, Scheme};
@@ -46,7 +46,7 @@ enum Inner {
     #[cfg(feature = "boring-tls")]
     BoringTls {
         http: HttpConnector,
-        tls: TlsConnector,
+        tls: BoringTlsConnector,
     },
 }
 
@@ -84,7 +84,7 @@ impl Connector {
     #[cfg(feature = "boring-tls")]
     pub(crate) fn new_boring_tls(
         mut http: HttpConnector,
-        tls: TlsConnector,
+        tls: BoringTlsConnector,
         proxies: Arc<Vec<Proxy>>,
         user_agent: Option<HeaderValue>,
         local_addr_v4: Option<Ipv4Addr>,

--- a/src/tls/connector/mod.rs
+++ b/src/tls/connector/mod.rs
@@ -9,7 +9,7 @@ use boring::ssl::{
     ConnectConfiguration, Ssl, SslConnector, SslConnectorBuilder, SslRef, SslSessionCacheMode,
 };
 
-use super::TlsResult;
+use super::SslResult;
 ///! Hyper SSL support via OpenSSL.
 use cache::{SessionCache, SessionKey};
 use http::uri::Scheme;
@@ -28,8 +28,8 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_boring::SslStream;
 use tower_layer::Layer;
 
-fn key_index() -> TlsResult<Index<Ssl, SessionKey>> {
-    static IDX: LazyLock<TlsResult<Index<Ssl, SessionKey>>> = LazyLock::new(Ssl::new_ex_index);
+fn key_index() -> SslResult<Index<Ssl, SessionKey>> {
+    static IDX: LazyLock<SslResult<Index<Ssl, SessionKey>>> = LazyLock::new(Ssl::new_ex_index);
     IDX.clone()
 }
 
@@ -41,11 +41,11 @@ struct Inner {
     ssl_callback: Option<SslCallback>,
 }
 
-type Callback = Arc<dyn Fn(&mut ConnectConfiguration, &Uri) -> TlsResult<()> + Sync + Send>;
-type SslCallback = Arc<dyn Fn(&mut SslRef, &Uri) -> TlsResult<()> + Sync + Send>;
+type Callback = Arc<dyn Fn(&mut ConnectConfiguration, &Uri) -> SslResult<()> + Sync + Send>;
+type SslCallback = Arc<dyn Fn(&mut SslRef, &Uri) -> SslResult<()> + Sync + Send>;
 
 impl Inner {
-    fn setup_ssl(&self, uri: &Uri, host: &str) -> TlsResult<Ssl> {
+    fn setup_ssl(&self, uri: &Uri, host: &str) -> SslResult<Ssl> {
         let mut conf = self.ssl.configure()?;
 
         if let Some(ref callback) = self.callback {
@@ -133,7 +133,7 @@ impl HttpsLayer {
     /// Creates a new `HttpsLayer`.
     ///
     /// The session cache configuration of `ssl` will be overwritten.
-    pub fn with_connector(ssl: SslConnectorBuilder) -> TlsResult<HttpsLayer> {
+    pub fn with_connector(ssl: SslConnectorBuilder) -> SslResult<HttpsLayer> {
         Self::with_connector_and_settings(ssl, Default::default())
     }
 
@@ -141,7 +141,7 @@ impl HttpsLayer {
     pub fn with_connector_and_settings(
         mut ssl: SslConnectorBuilder,
         settings: HttpsLayerSettings,
-    ) -> TlsResult<HttpsLayer> {
+    ) -> SslResult<HttpsLayer> {
         // If the session cache is disabled, we don't need to set up any callbacks.
         let cache = if settings.session_cache {
             let cache = Arc::new(Mutex::new(SessionCache::with_capacity(
@@ -181,7 +181,7 @@ impl HttpsLayer {
     /// instead.
     pub fn set_callback<F>(&mut self, callback: F)
     where
-        F: Fn(&mut ConnectConfiguration, &Uri) -> TlsResult<()> + 'static + Sync + Send,
+        F: Fn(&mut ConnectConfiguration, &Uri) -> SslResult<()> + 'static + Sync + Send,
     {
         self.inner.callback = Some(Arc::new(callback));
     }
@@ -189,7 +189,7 @@ impl HttpsLayer {
     /// Registers a callback which can customize the `Ssl` of each connection.
     pub fn set_ssl_callback<F>(&mut self, callback: F)
     where
-        F: Fn(&mut SslRef, &Uri) -> TlsResult<()> + 'static + Sync + Send,
+        F: Fn(&mut SslRef, &Uri) -> SslResult<()> + 'static + Sync + Send,
     {
         self.inner.ssl_callback = Some(Arc::new(callback));
     }
@@ -228,26 +228,8 @@ where
         }
     }
 
-    /// Creates a new `HttpsConnector`.
-    ///
-    /// The session cache configuration of `ssl` will be overwritten.
-    pub fn with_connector(http: S, ssl: SslConnectorBuilder) -> TlsResult<HttpsConnector<S>> {
-        HttpsLayer::with_connector(ssl).map(|l| l.layer(http))
-    }
-
-    /// Creates a new `HttpsConnector` with settings
-    ///
-    /// The session cache configuration of `ssl` will be overwritten.
-    pub fn with_connector_and_settings(
-        http: S,
-        ssl: SslConnectorBuilder,
-        settings: HttpsLayerSettings,
-    ) -> TlsResult<HttpsConnector<S>> {
-        HttpsLayer::with_connector_and_settings(ssl, settings).map(|l| l.layer(http))
-    }
-
     /// Configures the SSL context for a given URI.
-    pub fn setup_ssl(&self, uri: &Uri, host: &str) -> TlsResult<Ssl> {
+    pub fn setup_ssl(&self, uri: &Uri, host: &str) -> SslResult<Ssl> {
         self.inner.setup_ssl(uri, host)
     }
 
@@ -258,7 +240,7 @@ where
     /// instead.
     pub fn set_callback<F>(&mut self, callback: F)
     where
-        F: Fn(&mut ConnectConfiguration, &Uri) -> TlsResult<()> + 'static + Sync + Send,
+        F: Fn(&mut ConnectConfiguration, &Uri) -> SslResult<()> + 'static + Sync + Send,
     {
         self.inner.callback = Some(Arc::new(callback));
     }
@@ -266,7 +248,7 @@ where
     /// Registers a callback which can customize the `Ssl` of each connection.
     pub fn set_ssl_callback<F>(&mut self, callback: F)
     where
-        F: Fn(&mut SslRef, &Uri) -> TlsResult<()> + 'static + Sync + Send,
+        F: Fn(&mut SslRef, &Uri) -> SslResult<()> + 'static + Sync + Send,
     {
         self.inner.ssl_callback = Some(Arc::new(callback));
     }

--- a/src/tls/impersonate/chrome/v100.rs
+++ b/src/tls/impersonate/chrome/v100.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v101.rs
+++ b/src/tls/impersonate/chrome/v101.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v104.rs
+++ b/src/tls/impersonate/chrome/v104.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v105.rs
+++ b/src/tls/impersonate/chrome/v105.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v106.rs
+++ b/src/tls/impersonate/chrome/v106.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v107.rs
+++ b/src/tls/impersonate/chrome/v107.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v108.rs
+++ b/src/tls/impersonate/chrome/v108.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v109.rs
+++ b/src/tls/impersonate/chrome/v109.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v114.rs
+++ b/src/tls/impersonate/chrome/v114.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v116.rs
+++ b/src/tls/impersonate/chrome/v116.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v117.rs
+++ b/src/tls/impersonate/chrome/v117.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v118.rs
+++ b/src/tls/impersonate/chrome/v118.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -12,11 +12,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v119.rs
+++ b/src/tls/impersonate/chrome/v119.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, DNT, UPGRADE_INSECURE_REQUESTS,
@@ -13,11 +13,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v120.rs
+++ b/src/tls/impersonate/chrome/v120.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, DNT, UPGRADE_INSECURE_REQUESTS,
@@ -13,11 +13,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v123.rs
+++ b/src/tls/impersonate/chrome/v123.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v124.rs
+++ b/src/tls/impersonate/chrome/v124.rs
@@ -1,8 +1,8 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::SslExtension;
 use crate::tls::extension::{ChromeExtension, Extension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -11,13 +11,13 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?
             .configure_cipher_list(&CIPHER_LIST)?
             .configure_chrome_new_curves()?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v126.rs
+++ b/src/tls/impersonate/chrome/v126.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,13 +10,13 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?
             .configure_cipher_list(&CIPHER_LIST)?
             .configure_chrome_new_curves()?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/chrome/v127.rs
+++ b/src/tls/impersonate/chrome/v127.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{ChromeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,13 +10,13 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: ChromeExtension::builder()?
             .configure_cipher_list(&CIPHER_LIST)?
             .configure_chrome_new_curves()?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/edge/edge101.rs
+++ b/src/tls/impersonate/edge/edge101.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{EdgeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: EdgeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/edge/edge122.rs
+++ b/src/tls/impersonate/edge/edge122.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{EdgeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: EdgeExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/edge/edge127.rs
+++ b/src/tls/impersonate/edge/edge127.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{EdgeExtension, Extension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,13 +10,13 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: EdgeExtension::builder()?
             .configure_cipher_list(&CIPHER_LIST)?
             .configure_chrome_new_curves()?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(6291456),
             initial_connection_window_size: Some(15728640),

--- a/src/tls/impersonate/mod.rs
+++ b/src/tls/impersonate/mod.rs
@@ -5,9 +5,13 @@ mod edge;
 mod okhttp;
 mod safari;
 
-use super::{SslBuilderSettings, TlsResult};
+use super::{SslImpersonateSettings, SslResult};
 use crate::tls::ImpersonateSettings;
+use chrome::*;
+use edge::*;
 use http::HeaderMap;
+use okhttp::*;
+use safari::*;
 use std::{fmt::Debug, str::FromStr};
 use Impersonate::*;
 
@@ -22,57 +26,60 @@ macro_rules! impersonate_match {
 }
 
 /// Get the connection settings for the given impersonate version
-pub fn tls_settings(ver: Impersonate, headers: &mut HeaderMap) -> TlsResult<SslBuilderSettings> {
+pub fn tls_settings(
+    ver: Impersonate,
+    headers: &mut HeaderMap,
+) -> SslResult<SslImpersonateSettings> {
     impersonate_match!(
         ver,
         headers,
         // Chrome
-        Chrome100 => chrome::v100::get_settings,
-        Chrome101 => chrome::v101::get_settings,
-        Chrome104 => chrome::v104::get_settings,
-        Chrome105 => chrome::v105::get_settings,
-        Chrome106 => chrome::v106::get_settings,
-        Chrome107 => chrome::v107::get_settings,
-        Chrome108 => chrome::v108::get_settings,
-        Chrome109 => chrome::v109::get_settings,
-        Chrome114 => chrome::v114::get_settings,
-        Chrome116 => chrome::v116::get_settings,
-        Chrome117 => chrome::v117::get_settings,
-        Chrome118 => chrome::v118::get_settings,
-        Chrome119 => chrome::v119::get_settings,
-        Chrome120 => chrome::v120::get_settings,
-        Chrome123 => chrome::v123::get_settings,
-        Chrome124 => chrome::v124::get_settings,
-        Chrome126 => chrome::v126::get_settings,
-        Chrome127 => chrome::v127::get_settings,
+        Chrome100 => v100::get_settings,
+        Chrome101 => v101::get_settings,
+        Chrome104 => v104::get_settings,
+        Chrome105 => v105::get_settings,
+        Chrome106 => v106::get_settings,
+        Chrome107 => v107::get_settings,
+        Chrome108 => v108::get_settings,
+        Chrome109 => v109::get_settings,
+        Chrome114 => v114::get_settings,
+        Chrome116 => v116::get_settings,
+        Chrome117 => v117::get_settings,
+        Chrome118 => v118::get_settings,
+        Chrome119 => v119::get_settings,
+        Chrome120 => v120::get_settings,
+        Chrome123 => v123::get_settings,
+        Chrome124 => v124::get_settings,
+        Chrome126 => v126::get_settings,
+        Chrome127 => v127::get_settings,
 
         // Safari
-        SafariIos17_2 => safari::safari_ios_17_2::get_settings,
-        SafariIos17_4_1 => safari::safari_ios_17_4_1::get_settings,
-        SafariIos16_5 => safari::safari_ios_16_5::get_settings,
-        Safari15_3 => safari::safari15_3::get_settings,
-        Safari15_5 => safari::safari15_5::get_settings,
-        Safari15_6_1 => safari::safari15_6_1::get_settings,
-        Safari16 => safari::safari16::get_settings,
-        Safari16_5 => safari::safari16_5::get_settings,
-        Safari17_0 => safari::safari17_0::get_settings,
-        Safari17_2_1 => safari::safari17_2_1::get_settings,
-        Safari17_4_1 => safari::safari17_4_1::get_settings,
-        Safari17_5 => safari::safari17_5::get_settings,
+        SafariIos17_2 => safari_ios_17_2::get_settings,
+        SafariIos17_4_1 => safari_ios_17_4_1::get_settings,
+        SafariIos16_5 => safari_ios_16_5::get_settings,
+        Safari15_3 => safari15_3::get_settings,
+        Safari15_5 => safari15_5::get_settings,
+        Safari15_6_1 => safari15_6_1::get_settings,
+        Safari16 => safari16::get_settings,
+        Safari16_5 => safari16_5::get_settings,
+        Safari17_0 => safari17_0::get_settings,
+        Safari17_2_1 => safari17_2_1::get_settings,
+        Safari17_4_1 => safari17_4_1::get_settings,
+        Safari17_5 => safari17_5::get_settings,
 
         // OkHttp
-        OkHttp3_9 => okhttp::okhttp3_9::get_settings,
-        OkHttp3_11 => okhttp::okhttp3_11::get_settings,
-        OkHttp3_13 => okhttp::okhttp3_13::get_settings,
-        OkHttp3_14 => okhttp::okhttp3_14::get_settings,
-        OkHttp4_9 => okhttp::okhttp4_9::get_settings,
-        OkHttp4_10 => okhttp::okhttp4_10::get_settings,
-        OkHttp5 => okhttp::okhttp5::get_settings,
+        OkHttp3_9 => okhttp3_9::get_settings,
+        OkHttp3_11 => okhttp3_11::get_settings,
+        OkHttp3_13 => okhttp3_13::get_settings,
+        OkHttp3_14 => okhttp3_14::get_settings,
+        OkHttp4_9 => okhttp4_9::get_settings,
+        OkHttp4_10 => okhttp4_10::get_settings,
+        OkHttp5 => okhttp5::get_settings,
 
         // Edge
-        Edge101 => edge::edge101::get_settings,
-        Edge122 => edge::edge122::get_settings,
-        Edge127 => edge::edge127::get_settings
+        Edge101 => edge101::get_settings,
+        Edge122 => edge122::get_settings,
+        Edge127 => edge127::get_settings
     )
 }
 
@@ -184,51 +191,4 @@ impl FromStr for Impersonate {
             _ => Err(format!("Unknown impersonate version: {}", s)),
         }
     }
-}
-
-impl Impersonate {
-    pub(super) fn pre_share_key(&self) -> bool {
-        matches!(
-            self,
-            Chrome116
-                | Chrome117
-                | Chrome120
-                | Chrome123
-                | Chrome124
-                | Chrome126
-                | Chrome127
-                | Edge122
-                | Edge127
-        )
-    }
-
-    pub(super) fn typed(&self) -> TypedImpersonate {
-        match self {
-            // Chrome
-            Chrome100 | Chrome101 | Chrome104 | Chrome105 | Chrome106 | Chrome107 | Chrome108
-            | Chrome109 | Chrome114 | Chrome116 | Chrome117 | Chrome118 | Chrome119 | Chrome120
-            | Chrome123 | Chrome124 | Chrome126 | Chrome127 => TypedImpersonate::Chrome,
-
-            // Safari
-            SafariIos17_2 | SafariIos16_5 | SafariIos17_4_1 | Safari15_3 | Safari15_5
-            | Safari15_6_1 | Safari16 | Safari16_5 | Safari17_0 | Safari17_2_1 | Safari17_4_1
-            | Safari17_5 => TypedImpersonate::Safari,
-
-            // OkHttp
-            OkHttp3_9 | OkHttp3_11 | OkHttp3_13 | OkHttp3_14 | OkHttp4_9 | OkHttp4_10 | OkHttp5 => {
-                TypedImpersonate::OkHttp
-            }
-
-            // Edge
-            Edge101 | Edge122 | Edge127 => TypedImpersonate::Edge,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum TypedImpersonate {
-    Chrome,
-    OkHttp,
-    Safari,
-    Edge,
 }

--- a/src/tls/impersonate/okhttp/okhttp3_11.rs
+++ b/src/tls/impersonate/okhttp/okhttp3_11.rs
@@ -1,6 +1,6 @@
 use crate::tls::extension::{Extension, OkHttpExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -9,9 +9,9 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: OkHttpExtension::builder()?.configure_cipher_list(&[
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -27,7 +27,7 @@ pub(crate) fn get_settings(
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
         ])?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),

--- a/src/tls/impersonate/okhttp/okhttp3_13.rs
+++ b/src/tls/impersonate/okhttp/okhttp3_13.rs
@@ -1,6 +1,6 @@
 use crate::tls::extension::{Extension, OkHttpExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -9,9 +9,9 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: OkHttpExtension::builder()?.configure_cipher_list(&[
             "TLS_AES_128_GCM_SHA256",
             "TLS_AES_256_GCM_SHA384",
@@ -32,7 +32,7 @@ pub(crate) fn get_settings(
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
         ])?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),

--- a/src/tls/impersonate/okhttp/okhttp3_14.rs
+++ b/src/tls/impersonate/okhttp/okhttp3_14.rs
@@ -1,6 +1,6 @@
 use crate::tls::extension::{Extension, OkHttpExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -9,9 +9,9 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: OkHttpExtension::builder()?.configure_cipher_list(&[
             "TLS_AES_128_GCM_SHA256",
             "TLS_AES_256_GCM_SHA384",
@@ -30,7 +30,7 @@ pub(crate) fn get_settings(
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
         ])?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),

--- a/src/tls/impersonate/okhttp/okhttp3_9.rs
+++ b/src/tls/impersonate/okhttp/okhttp3_9.rs
@@ -1,6 +1,6 @@
 use crate::tls::extension::{Extension, OkHttpExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -9,9 +9,9 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: OkHttpExtension::builder()?.configure_cipher_list(&[
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -29,7 +29,7 @@ pub(crate) fn get_settings(
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
         ])?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),

--- a/src/tls/impersonate/okhttp/okhttp4_10.rs
+++ b/src/tls/impersonate/okhttp/okhttp4_10.rs
@@ -1,6 +1,6 @@
 use crate::tls::extension::{Extension, OkHttpExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -9,9 +9,9 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: OkHttpExtension::builder()?.configure_cipher_list(&[
             "TLS_AES_128_GCM_SHA256",
             "TLS_AES_256_GCM_SHA384",
@@ -30,7 +30,7 @@ pub(crate) fn get_settings(
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
         ])?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),

--- a/src/tls/impersonate/okhttp/okhttp4_9.rs
+++ b/src/tls/impersonate/okhttp/okhttp4_9.rs
@@ -1,6 +1,6 @@
 use crate::tls::extension::{Extension, OkHttpExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -9,9 +9,9 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: OkHttpExtension::builder()?.configure_cipher_list(&[
             "TLS_AES_128_GCM_SHA256",
             "TLS_AES_256_GCM_SHA384",
@@ -29,7 +29,7 @@ pub(crate) fn get_settings(
             "TLS_RSA_WITH_AES_128_CBC_SHA",
             "TLS_RSA_WITH_AES_256_CBC_SHA",
         ])?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),

--- a/src/tls/impersonate/okhttp/okhttp5.rs
+++ b/src/tls/impersonate/okhttp/okhttp5.rs
@@ -1,6 +1,6 @@
 use crate::tls::extension::{Extension, OkHttpExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -9,9 +9,9 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: OkHttpExtension::builder()?.configure_cipher_list(&[
             "TLS_AES_128_GCM_SHA256",
             "TLS_AES_256_GCM_SHA384",
@@ -30,7 +30,7 @@ pub(crate) fn get_settings(
             "TLS_RSA_WITH_AES_256_CBC_SHA",
             "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
         ])?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(16777216),
             initial_connection_window_size: Some(16777216),

--- a/src/tls/impersonate/safari/safari15_3.rs
+++ b/src/tls/impersonate/safari/safari15_3.rs
@@ -1,7 +1,7 @@
 use super::OLD_CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&OLD_CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari15_5.rs
+++ b/src/tls/impersonate/safari/safari15_5.rs
@@ -1,7 +1,7 @@
 use super::OLD_CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&OLD_CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari15_6_1.rs
+++ b/src/tls/impersonate/safari/safari15_6_1.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari16.rs
+++ b/src/tls/impersonate/safari/safari16.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari16_5.rs
+++ b/src/tls/impersonate/safari/safari16_5.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari17_0.rs
+++ b/src/tls/impersonate/safari/safari17_0.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari17_2_1.rs
+++ b/src/tls/impersonate/safari/safari17_2_1.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari17_4_1.rs
+++ b/src/tls/impersonate/safari/safari17_4_1.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari17_5.rs
+++ b/src/tls/impersonate/safari/safari17_5.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(4194304),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari_ios_16_5.rs
+++ b/src/tls/impersonate/safari/safari_ios_16_5.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(2097152),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari_ios_17_2.rs
+++ b/src/tls/impersonate/safari/safari_ios_17_2.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(2097152),
             initial_connection_window_size: Some(10551295),

--- a/src/tls/impersonate/safari/safari_ios_17_4_1.rs
+++ b/src/tls/impersonate/safari/safari_ios_17_4_1.rs
@@ -1,7 +1,7 @@
 use super::CIPHER_LIST;
 use crate::tls::extension::{Extension, SafariExtension, SslExtension};
-use crate::tls::{Http2Settings, SslBuilderSettings};
-use crate::tls::{ImpersonateSettings, TlsResult};
+use crate::tls::{Http2Settings, SslImpersonateSettings};
+use crate::tls::{ImpersonateSettings, SslResult};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -10,11 +10,11 @@ use http::{
 pub(crate) fn get_settings(
     settings: ImpersonateSettings,
     headers: &mut HeaderMap,
-) -> TlsResult<SslBuilderSettings> {
+) -> SslResult<SslImpersonateSettings> {
     init_headers(headers);
-    Ok(SslBuilderSettings {
+    Ok(SslImpersonateSettings {
         ssl_builder: SafariExtension::builder()?.configure_cipher_list(&CIPHER_LIST)?,
-        pre_shared_key: settings.pre_share_key,
+        extension: settings.extension,
         http2: Http2Settings {
             initial_stream_window_size: Some(2097152),
             initial_connection_window_size: Some(10551295),


### PR DESCRIPTION
Optional configuration of TLS SNI to solve the problem of not supporting IP certificates

ref: https://github.com/sfackler/rust-openssl/pull/1866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SSL configuration with the introduction of `SslImpersonateSettings`, improving clarity for impersonation scenarios.
	- New method for managing TLS Server Name Indication (SNI) settings added.
  
- **Refactor**
	- Streamlined error handling by transitioning from `TlsResult` to `SslResult`, enhancing consistency in error reporting.
	- Simplified management of TLS settings by replacing `pre_shared_key` with an `extension` field in various settings structures.

- **Bug Fixes**
	- Adjusted the handling of TLS version parameters to ensure consistent configuration management across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->