### PR TITLE
refactor(client): set_proxies accepts an slice of references

### DIFF
--- a/examples/set_proxies.rs
+++ b/examples/set_proxies.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", resp.text().await?);
 
     let proxy = rquest::Proxy::all("socks5h://127.0.0.1:1080")?;
-    client.set_proxies(vec![proxy]);
+    client.set_proxies(&[proxy]);
 
     let resp = client.get("https://api.ip.sb/ip").send().await?;
     println!("{}", resp.text().await?);

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1515,7 +1515,7 @@ impl Client {
     }
 
     /// Set the proxies for this client.
-    pub fn set_proxies(&mut self, proxies: Vec<Proxy>) {
+    pub fn set_proxies(&mut self, proxies: &[Proxy]) {
         Arc::make_mut(&mut self.inner).hyper.set_proxies(proxies);
         self.inner.hyper.reset_pool_idle();
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -138,8 +138,8 @@ impl Connector {
         self.proxies.clone()
     }
 
-    pub(crate) fn set_proxies(&mut self, proxies: Vec<Proxy>) {
-        Arc::make_mut(&mut self.proxies).clone_from_slice(&proxies);
+    pub(crate) fn set_proxies(&mut self, proxies: &[Proxy]) {
+        Arc::make_mut(&mut self.proxies).clone_from_slice(proxies);
     }
 
     pub(crate) fn set_local_address(&mut self, addr: Option<IpAddr>) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `set_proxies` methods across the application to accept a slice of `Proxy` instances, improving flexibility and performance.
  
- **Bug Fixes**
	- Streamlined method interfaces by eliminating unnecessary allocations, improving overall efficiency.

- **Documentation**
	- Updated method signatures to reflect changes in parameter types, ensuring clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->