### PR TITLE
feat(client): Add `impersonate_with_headers` allows optionally setting request headers

### DIFF
--- a/examples/impersonate_with_headers.rs
+++ b/examples/impersonate_with_headers.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // Build a client to mimic Edge127
+    // Build a client to mimic Edge127 with headers
     let client = rquest::Client::builder()
         .impersonate_with_headers(Impersonate::Edge127, false)
         .enable_ech_grease()

--- a/examples/impersonate_with_headers.rs
+++ b/examples/impersonate_with_headers.rs
@@ -1,0 +1,18 @@
+use rquest::tls::Impersonate;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Build a client to mimic Edge127
+    let client = rquest::Client::builder()
+        .impersonate_with_headers(Impersonate::Edge127, false)
+        .enable_ech_grease()
+        .permute_extensions()
+        .build()?;
+
+    // Use the API you're already familiar with
+    let resp = client.get("https://tls.peet.ws/api/all").send().await?;
+    println!("{}", resp.text().await?);
+
+    Ok(())
+}

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -277,19 +277,19 @@ impl ClientBuilder {
         set_headers: bool,
     ) -> ClientBuilder {
         // Try to get the settings for the impersonate version
-        if let Ok((settings, func)) = tls::tls_settings(impersonate) {
-            return self.apply_tls_settings(settings, func, set_headers);
+        if let Ok((settings, header_initializer)) = tls::tls_settings(impersonate) {
+            return self.apply_tls_settings(settings, header_initializer, set_headers);
         }
         self
     }
 
     /// Use the preconfigured TLS settings.
     #[cfg(feature = "boring-tls")]
-    pub fn use_preconfigured_tls<F>(self, settings: TlsSettings, func: F) -> ClientBuilder
+    pub fn use_preconfigured_tls<F>(self, settings: TlsSettings, header_initializer: F) -> ClientBuilder
     where
         F: FnOnce(&mut HeaderMap),
     {
-        self.apply_tls_settings(settings, func, true)
+        self.apply_tls_settings(settings, header_initializer, true)
     }
 
     /// Apply the given TLS settings and header function.

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -285,7 +285,11 @@ impl ClientBuilder {
 
     /// Use the preconfigured TLS settings.
     #[cfg(feature = "boring-tls")]
-    pub fn use_preconfigured_tls<F>(self, settings: TlsSettings, header_initializer: F) -> ClientBuilder
+    pub fn use_preconfigured_tls<F>(
+        self,
+        settings: TlsSettings,
+        header_initializer: F,
+    ) -> ClientBuilder
     where
         F: FnOnce(&mut HeaderMap),
     {

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -301,14 +301,14 @@ impl ClientBuilder {
     fn apply_tls_settings<F>(
         mut self,
         settings: TlsSettings,
-        func: F,
+        header_initializer: F,
         set_headers: bool,
     ) -> ClientBuilder
     where
         F: FnOnce(&mut HeaderMap),
     {
         if set_headers {
-            func(&mut self.config.headers);
+            header_initializer(&mut self.config.headers);
         }
         self.config.tls.builder = Some(settings.builder);
         self.config.tls.extension = settings.extension;

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -271,7 +271,11 @@ impl ClientBuilder {
     /// This will set the necessary headers and TLS settings.
     /// This is only available with the `boring-tls` feature.
     #[cfg(feature = "boring-tls")]
-    pub fn impersonate_with_headers(self, impersonate: Impersonate, set_headers: bool) -> ClientBuilder {
+    pub fn impersonate_with_headers(
+        self,
+        impersonate: Impersonate,
+        set_headers: bool,
+    ) -> ClientBuilder {
         // Try to get the settings for the impersonate version
         if let Ok((settings, func)) = tls::tls_settings(impersonate) {
             return self.apply_tls_settings(settings, func, set_headers);
@@ -290,7 +294,12 @@ impl ClientBuilder {
 
     /// Apply the given TLS settings and header function.
     #[cfg(feature = "boring-tls")]
-    fn apply_tls_settings<F>(mut self, settings: TlsSettings, func: F, set_headers: bool) -> ClientBuilder
+    fn apply_tls_settings<F>(
+        mut self,
+        settings: TlsSettings,
+        func: F,
+        set_headers: bool,
+    ) -> ClientBuilder
     where
         F: FnOnce(&mut HeaderMap),
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an asynchronous HTTP client that can impersonate specific entities with customizable headers.
	- Added a method to the client builder for enhanced impersonation capabilities while managing headers.
- **Improvements**
	- Enhanced flexibility in TLS settings application by allowing users to specify whether to apply headers during impersonation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->