### PR TITLE
refactor(websocket): Replace `async-tungstenite` with lighter `tokio-tungstenite` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ full = [
     "deflate",
 ]
 
-websocket = ["dep:async-tungstenite", "tokio-util/compat"]
+websocket = ["dep:tokio-tungstenite"]
 
 charset = ["dep:encoding_rs"]
 
@@ -147,7 +147,7 @@ tokio-util = { version = "0.7.0", default-features = false, features = [
 tokio-socks = { version = "0.5.2", optional = true }
 
 ## websocket
-async-tungstenite = { version = "0.28.0", optional = true }
+tokio-tungstenite = { version = "0.26.0", default-features = false, features = ["handshake"], optional = true }
 
 ## hickory-dns
 hickory-resolver = { version = "0.24", optional = true }

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -7,7 +7,7 @@
 
 use futures_util::{SinkExt, StreamExt, TryStreamExt};
 use http::header;
-use rquest::{Client, Impersonate, Message, RequestBuilder};
+use rquest::{Client, Impersonate, Message, RequestBuilder, Utf8Bytes};
 use std::time::Duration;
 
 #[tokio::main]
@@ -35,16 +35,20 @@ async fn main() -> Result<(), rquest::Error> {
 
     tokio::spawn(async move {
         for i in 1..11 {
-            tx.send(Message::Text(format!("Hello, World! #{i}")))
+            if let Err(err) = tx
+                .send(Message::Text(Utf8Bytes::from(format!(
+                    "Hello, World! #{i}"
+                ))))
                 .await
-                .unwrap();
+            {
+                eprintln!("failed to send message: {err}");
+            }
         }
     });
 
     while let Some(message) = rx.try_next().await? {
-        match message {
-            Message::Text(text) => println!("received: {text}"),
-            _ => {}
+        if let Message::Text(text) = message {
+            println!("received: {text}");
         }
     }
 

--- a/src/client/websocket/json.rs
+++ b/src/client/websocket/json.rs
@@ -1,5 +1,8 @@
 use crate::{Error, Message};
+use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
+
+use super::Utf8Bytes;
 
 impl Message {
     /// Tries to serialize the JSON as a [`Message::Text`].
@@ -15,6 +18,7 @@ impl Message {
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn text_from_json<T: Serialize + ?Sized>(json: &T) -> Result<Self, Error> {
         serde_json::to_string(json)
+            .map(Utf8Bytes::from)
             .map(Message::Text)
             .map_err(Into::into)
     }
@@ -32,6 +36,7 @@ impl Message {
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn binary_from_json<T: Serialize + ?Sized>(json: &T) -> Result<Self, Error> {
         serde_json::to_vec(json)
+            .map(Bytes::from)
             .map(Message::Binary)
             .map_err(Into::into)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -231,9 +231,16 @@ impl StdError for Error {
 }
 
 #[cfg(feature = "websocket")]
-impl From<async_tungstenite::tungstenite::Error> for Error {
-    fn from(err: async_tungstenite::tungstenite::Error) -> Error {
+impl From<tokio_tungstenite::tungstenite::Error> for Error {
+    fn from(err: tokio_tungstenite::tungstenite::Error) -> Error {
         Error::new(Kind::Upgrade, Some(err))
+    }
+}
+
+#[cfg(feature = "websocket")]
+impl From<std::str::Utf8Error> for Error {
+    fn from(err: std::str::Utf8Error) -> Error {
+        Error::new(Kind::Decode, Some(err))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,8 @@ doc_comment::doctest!("../README.md");
 pub use self::client::multipart;
 #[cfg(feature = "websocket")]
 pub use self::client::websocket::{
-    CloseCode, Message, WebSocket, WebSocketRequestBuilder, WebSocketResponse,
+    CloseCode, CloseFrame, Message, Utf8Bytes, WebSocket, WebSocketRequestBuilder,
+    WebSocketResponse,
 };
 pub use self::client::{
     Body, Client, ClientBuilder, ClientMut, Request, RequestBuilder, Response, Upgraded,


### PR DESCRIPTION
refactor: Replace async-tungstenite with lighter tokio-tungstenite implementation

- Replaced `async-tungstenite` dependency with `tokio-tungstenite` for a lighter implementation.
- Updated Cargo.toml to reflect the new dependency.
- Adjusted WebSocket-related code to work with `tokio-tungstenite`.
- Improved overall performance and reduced dependency bloat.