### PR TITLE
chore: fmt imports

### DIFF
--- a/src/imp/chrome.rs
+++ b/src/imp/chrome.rs
@@ -14,14 +14,14 @@ macro_rules! mod_generator {
             use super::*;
 
             #[inline(always)]
-            pub fn http_config(os_choice: ImpersonateOS, skip_http2: bool, skip_headers: bool) -> HttpContext {
+            pub fn http_context(option: ImpersonateOption) -> HttpContext {
                 #[allow(unreachable_patterns)]
-                match os_choice {
+                match option.impersonate_os {
                     $(
                         ImpersonateOS::$other_os => HttpContext::builder()
                             .tls_config($tls_config)
-                            .http2_config(conditional_http2!(skip_http2, $http2_config))
-                            .default_headers(conditional_headers!(skip_headers, || {
+                            .http2_config(conditional_http2!(option.skip_http2, $http2_config))
+                            .default_headers(conditional_headers!(option.skip_headers, || {
                                 $header_initializer(
                                     $other_sec_ch_ua,
                                     $other_ua,
@@ -32,8 +32,8 @@ macro_rules! mod_generator {
                     )*
                     _ => HttpContext::builder()
                         .tls_config($tls_config)
-                        .http2_config(conditional_http2!(skip_http2, $http2_config))
-                        .default_headers(conditional_headers!(skip_headers, || {
+                        .http2_config(conditional_http2!(option.skip_http2, $http2_config))
+                        .default_headers(conditional_headers!(option.skip_headers, || {
                             $header_initializer(
                                 $default_sec_ch_ua,
                                 $default_ua,

--- a/src/imp/firefox.rs
+++ b/src/imp/firefox.rs
@@ -14,23 +14,23 @@ macro_rules! mod_generator {
             use super::*;
 
             #[inline(always)]
-            pub fn http_config(os_choice: ImpersonateOS, skip_http2: bool, skip_headers: bool) -> HttpContext {
+            pub fn http_context(option: ImpersonateOption) -> HttpContext {
                 #[allow(unreachable_patterns)]
-                match os_choice {
+                match option.impersonate_os {
                     $(
                         ImpersonateOS::$other_os => {
                             HttpContext::builder()
                                 .tls_config($tls_config)
-                                .http2_config(conditional_http2!(skip_http2, $http2_config))
-                                .default_headers(conditional_headers!(skip_headers, $header_initializer, $other_ua))
+                                .http2_config(conditional_http2!(option.skip_http2, $http2_config))
+                                .default_headers(conditional_headers!(option.skip_headers, $header_initializer, $other_ua))
                                 .build()
                         }
                     ),*
                     _ => {
                         HttpContext::builder()
                             .tls_config($tls_config)
-                            .http2_config(conditional_http2!(skip_http2, $http2_config))
-                            .default_headers(conditional_headers!(skip_headers, $header_initializer, $default_ua))
+                            .http2_config(conditional_http2!(option.skip_http2, $http2_config))
+                            .default_headers(conditional_headers!(option.skip_headers, $header_initializer, $default_ua))
                             .build()
                     }
                 }

--- a/src/imp/macros.rs
+++ b/src/imp/macros.rs
@@ -147,10 +147,10 @@ macro_rules! join {
 }
 
 macro_rules! impersonate_match {
-    ($ver:expr, $os:expr, $skip_http2:expr, $skip_headers:expr, $($variant:pat => $path:expr),+) => {
+    ($ver:expr, $opt:expr, $($variant:pat => $path:expr),+) => {
         match $ver {
             $(
-                $variant => $path($os, $skip_http2, $skip_headers),
+                $variant => $path($opt),
             )+
         }
     }

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -1,4 +1,4 @@
-//! Impersonate http_config for different browsers.
+//! Impersonate http_context for different browsers.
 #![allow(missing_debug_implementations)]
 #![allow(missing_docs)]
 
@@ -12,7 +12,6 @@ mod safari;
 use crate::{HttpContext, HttpContextProvider};
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
-use Impersonate::*;
 
 use chrome::*;
 use firefox::*;
@@ -20,7 +19,7 @@ use okhttp::*;
 use safari::*;
 
 mod impersonate_imports {
-    pub use crate::{Http2Config, HttpContext, ImpersonateOS};
+    pub use crate::{Http2Config, HttpContext, ImpersonateOS, ImpersonateOption};
     pub use http::{
         header::{ACCEPT, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
         HeaderMap, HeaderName, HeaderValue,
@@ -278,66 +277,65 @@ impl HttpContextProvider for ImpersonateOption {
     fn context(self) -> HttpContext {
         impersonate_match!(
             self.impersonate,
-            self.impersonate_os,
-            self.skip_http2,
-            self.skip_headers,
-            Chrome100 => v100::http_config,
-            Chrome101 => v101::http_config,
-            Chrome104 => v104::http_config,
-            Chrome105 => v105::http_config,
-            Chrome106 => v106::http_config,
-            Chrome107 => v107::http_config,
-            Chrome108 => v108::http_config,
-            Chrome109 => v109::http_config,
-            Chrome114 => v114::http_config,
-            Chrome116 => v116::http_config,
-            Chrome117 => v117::http_config,
-            Chrome118 => v118::http_config,
-            Chrome119 => v119::http_config,
-            Chrome120 => v120::http_config,
-            Chrome123 => v123::http_config,
-            Chrome124 => v124::http_config,
-            Chrome126 => v126::http_config,
-            Chrome127 => v127::http_config,
-            Chrome128 => v128::http_config,
-            Chrome129 => v129::http_config,
-            Chrome130 => v130::http_config,
-            Chrome131 => v131::http_config,
+            self,
 
-            SafariIos17_2 => safari_ios_17_2::http_config,
-            SafariIos17_4_1 => safari_ios_17_4_1::http_config,
-            SafariIos16_5 => safari_ios_16_5::http_config,
-            Safari15_3 => safari15_3::http_config,
-            Safari15_5 => safari15_5::http_config,
-            Safari15_6_1 => safari15_6_1::http_config,
-            Safari16 => safari16::http_config,
-            Safari16_5 => safari16_5::http_config,
-            Safari17_0 => safari17_0::http_config,
-            Safari17_2_1 => safari17_2_1::http_config,
-            Safari17_4_1 => safari17_4_1::http_config,
-            Safari17_5 => safari17_5::http_config,
-            Safari18 => safari18::http_config,
-            SafariIPad18 => safari_ipad_18::http_config,
-            Safari18_2 => safari18_2::http_config,
-            SafariIos18_1_1 => safari_ios_18_1_1::http_config,
+            Impersonate::Chrome100 => v100::http_context,
+            Impersonate::Chrome101 => v101::http_context,
+            Impersonate::Chrome104 => v104::http_context,
+            Impersonate::Chrome105 => v105::http_context,
+            Impersonate::Chrome106 => v106::http_context,
+            Impersonate::Chrome107 => v107::http_context,
+            Impersonate::Chrome108 => v108::http_context,
+            Impersonate::Chrome109 => v109::http_context,
+            Impersonate::Chrome114 => v114::http_context,
+            Impersonate::Chrome116 => v116::http_context,
+            Impersonate::Chrome117 => v117::http_context,
+            Impersonate::Chrome118 => v118::http_context,
+            Impersonate::Chrome119 => v119::http_context,
+            Impersonate::Chrome120 => v120::http_context,
+            Impersonate::Chrome123 => v123::http_context,
+            Impersonate::Chrome124 => v124::http_context,
+            Impersonate::Chrome126 => v126::http_context,
+            Impersonate::Chrome127 => v127::http_context,
+            Impersonate::Chrome128 => v128::http_context,
+            Impersonate::Chrome129 => v129::http_context,
+            Impersonate::Chrome130 => v130::http_context,
+            Impersonate::Chrome131 => v131::http_context,
 
-            OkHttp3_9 => okhttp3_9::http_config,
-            OkHttp3_11 => okhttp3_11::http_config,
-            OkHttp3_13 => okhttp3_13::http_config,
-            OkHttp3_14 => okhttp3_14::http_config,
-            OkHttp4_9 => okhttp4_9::http_config,
-            OkHttp4_10 => okhttp4_10::http_config,
-            OkHttp5 => okhttp5::http_config,
+            Impersonate::SafariIos17_2 => safari_ios_17_2::http_context,
+            Impersonate::SafariIos17_4_1 => safari_ios_17_4_1::http_context,
+            Impersonate::SafariIos16_5 => safari_ios_16_5::http_context,
+            Impersonate::Safari15_3 => safari15_3::http_context,
+            Impersonate::Safari15_5 => safari15_5::http_context,
+            Impersonate::Safari15_6_1 => safari15_6_1::http_context,
+            Impersonate::Safari16 => safari16::http_context,
+            Impersonate::Safari16_5 => safari16_5::http_context,
+            Impersonate::Safari17_0 => safari17_0::http_context,
+            Impersonate::Safari17_2_1 => safari17_2_1::http_context,
+            Impersonate::Safari17_4_1 => safari17_4_1::http_context,
+            Impersonate::Safari17_5 => safari17_5::http_context,
+            Impersonate::Safari18 => safari18::http_context,
+            Impersonate::SafariIPad18 => safari_ipad_18::http_context,
+            Impersonate::Safari18_2 => safari18_2::http_context,
+            Impersonate::SafariIos18_1_1 => safari_ios_18_1_1::http_context,
 
-            Edge101 => edge101::http_config,
-            Edge122 => edge122::http_config,
-            Edge127 => edge127::http_config,
-            Edge131 => edge131::http_config,
+            Impersonate::OkHttp3_9 => okhttp3_9::http_context,
+            Impersonate::OkHttp3_11 => okhttp3_11::http_context,
+            Impersonate::OkHttp3_13 => okhttp3_13::http_context,
+            Impersonate::OkHttp3_14 => okhttp3_14::http_context,
+            Impersonate::OkHttp4_9 => okhttp4_9::http_context,
+            Impersonate::OkHttp4_10 => okhttp4_10::http_context,
+            Impersonate::OkHttp5 => okhttp5::http_context,
 
-            Firefox109 => ff109::http_config,
-            Firefox117 => ff117::http_config,
-            Firefox128 => ff128::http_config,
-            Firefox133 => ff133::http_config
+            Impersonate::Edge101 => edge101::http_context,
+            Impersonate::Edge122 => edge122::http_context,
+            Impersonate::Edge127 => edge127::http_context,
+            Impersonate::Edge131 => edge131::http_context,
+
+            Impersonate::Firefox109 => ff109::http_context,
+            Impersonate::Firefox117 => ff117::http_context,
+            Impersonate::Firefox128 => ff128::http_context,
+            Impersonate::Firefox133 => ff133::http_context
         )
     }
 }

--- a/src/imp/okhttp.rs
+++ b/src/imp/okhttp.rs
@@ -8,16 +8,12 @@ macro_rules! mod_generator {
             use super::*;
 
             #[inline(always)]
-            pub fn http_config(
-                _: ImpersonateOS,
-                skip_http2: bool,
-                skip_headers: bool,
-            ) -> HttpContext {
+            pub fn http_context(option: ImpersonateOption) -> HttpContext {
                 HttpContext::builder()
                     .tls_config(tls_config!($cipher_list))
-                    .http2_config(conditional_http2!(skip_http2, http2_config!()))
+                    .http2_config(conditional_http2!(option.skip_http2, http2_config!()))
                     .default_headers(conditional_headers!(
-                        skip_headers,
+                        option.skip_headers,
                         super::header_initializer,
                         $ua
                     ))

--- a/src/imp/safari.rs
+++ b/src/imp/safari.rs
@@ -8,15 +8,15 @@ macro_rules! mod_generator {
             use super::*;
 
             #[inline(always)]
-            pub fn http_config(
-                _: ImpersonateOS,
-                skip_http2: bool,
-                skip_headers: bool,
-            ) -> HttpContext {
+            pub fn http_context(option: ImpersonateOption) -> HttpContext {
                 HttpContext::builder()
                     .tls_config($tls_config)
-                    .http2_config(conditional_http2!(skip_http2, $http2_config))
-                    .default_headers(conditional_headers!(skip_headers, $header_initializer, $ua))
+                    .http2_config(conditional_http2!(option.skip_http2, $http2_config))
+                    .default_headers(conditional_headers!(
+                        option.skip_headers,
+                        $header_initializer,
+                        $ua
+                    ))
                     .build()
             }
         }


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and functionality of the HTTP context configuration across different browser impersonations. The most significant changes involve refactoring function names and parameters to enhance clarity and maintainability.

Refactoring for improved clarity and consistency:

* `src/imp/chrome.rs`, `src/imp/firefox.rs`, `src/imp/okhttp.rs`, `src/imp/safari.rs`: Renamed the function `http_config` to `http_context` and updated the function parameters to use `ImpersonateOption` instead of individual parameters for `skip_http2` and `skip_headers`. [[1]](diffhunk://#diff-d3a45118246025f394197b05c790e52fe4eaa04b165f71aa92220d4d6a41cfc5L17-R24) [[2]](diffhunk://#diff-d3a45118246025f394197b05c790e52fe4eaa04b165f71aa92220d4d6a41cfc5L35-R36) [[3]](diffhunk://#diff-e8b467aee9eaef1a74e79abbfce108d5986b93274c32c702cf7c24abb53db6dfL17-R33) [[4]](diffhunk://#diff-001e77a1a6bac73cee5c6f971aca5825ec61c264c96bcfd7d7f197db0d6e38efL11-R16) [[5]](diffhunk://#diff-c0f5e53c64d1a2e3534644ce7216934cfe5823853c118a5bfde186be458d672bL11-R19)

* [`src/imp/macros.rs`](diffhunk://#diff-56a89d45ff06f05a91745238670e0db1c0e68aae81a0e97573b94b4be47dcda7L150-R153): Updated the `impersonate_match` macro to use the new `ImpersonateOption` parameter instead of separate parameters for `os`, `skip_http2`, and `skip_headers`.

* [`src/imp/mod.rs`](diffhunk://#diff-69df82777992a617abedaef86add8fbd567bf0c4aa2369e6adb3b0be1967f6d2L1-R1): Modified the `HttpContextProvider` implementation to use the new `http_context` function and updated the documentation to reflect the changes. [[1]](diffhunk://#diff-69df82777992a617abedaef86add8fbd567bf0c4aa2369e6adb3b0be1967f6d2L1-R1) [[2]](diffhunk://#diff-69df82777992a617abedaef86add8fbd567bf0c4aa2369e6adb3b0be1967f6d2L15-R22) [[3]](diffhunk://#diff-69df82777992a617abedaef86add8fbd567bf0c4aa2369e6adb3b0be1967f6d2L281-R338)

Dependency and import adjustments:

* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90R2-R57): Reorganized and cleaned up the import statements to ensure all necessary dependencies are included and unused ones are removed.