### PR TITLE
deps(tokio): Remove unused `rt` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,7 @@ hyper2 = { version = "1.5.0", features = ["http1", "http2", "client"] }
 log = "0.4"
 mime = "0.3.17"
 percent-encoding = "2.3"
-tokio = { version = "1", default-features = false, features = [
-    "net",
-    "time",
-    "rt",
-] }
+tokio = { version = "1", default-features = false, features = ["net","time"] }
 pin-project-lite = "0.2.0"
 ipnet = "2.10.0"
 


### PR DESCRIPTION
This pull request includes a change to the `Cargo.toml` file to update the dependencies for the project. The most important change involves modifying the `tokio` dependency to streamline its features.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L103-R103): Modified the `tokio` dependency to remove the `rt` feature, keeping only `net` and `time` features.