### PR TITLE
deps(ipnet): bump version to v2.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,7 @@ hyper2 = { version = "1.5.0", features = ["http1", "http2", "client"] }
 log = "0.4"
 mime = "0.3.17"
 percent-encoding = "2.3"
-tokio = { version = "1", default-features = false, features = [
-    "net",
-    "time",
-    "rt",
-] }
+tokio = { version = "1", default-features = false, features = ["net","time"] }
 pin-project-lite = "0.2.0"
 ipnet = "2.10.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ mime = "0.3.17"
 percent-encoding = "2.3"
 tokio = { version = "1", default-features = false, features = ["net","time"] }
 pin-project-lite = "0.2.0"
-ipnet = "2.10.0"
+ipnet = "2.11.0"
 
 # hyper util
 socket2 = { version = "0.5", features = ["all"] }


### PR DESCRIPTION
This pull request includes updates to dependencies in the `Cargo.toml` file. The most important changes include modifying the features of the `tokio` dependency and updating the version of the `ipnet` dependency.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L103-R105): Modified the `tokio` dependency to remove the `rt` feature and condense the feature list into a single line.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L103-R105): Updated the `ipnet` dependency from version `2.10.0` to `2.11.0`.