### PR TITLE
feat(client): Apply configuration sequentially

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -23,8 +23,8 @@ use crate::into_url::try_uri;
 use crate::util::{
     self,
     client::{
-        connect::HttpConnector, Builder, Http1Builder, Http2Builder, InnerRequest, NetworkScheme,
-        NetworkSchemeBuilder,
+        connect::HttpConnector, Builder, Client as HyperClient, Http1Builder, Http2Builder,
+        InnerRequest, NetworkScheme, NetworkSchemeBuilder,
     },
     rt::{tokio::TokioTimer, TokioExecutor},
 };
@@ -168,7 +168,7 @@ impl ClientBuilder {
                 dns_overrides: HashMap::new(),
                 dns_resolver: None,
                 base_url: None,
-                builder: util::client::Client::builder(TokioExecutor::new()),
+                builder: HyperClient::builder(TokioExecutor::new()),
                 https_only: false,
                 http2_max_retry_count: 2,
                 tls_info: false,
@@ -1177,8 +1177,6 @@ impl ClientBuilder {
     }
 }
 
-type HyperClient = util::client::Client<Connector, super::Body>;
-
 impl Default for Client {
     fn default() -> Self {
         Self::new()
@@ -1630,7 +1628,7 @@ struct ClientRef {
     cookie_store: Option<Arc<dyn cookie::CookieStore>>,
     headers: HeaderMap,
     headers_order: Option<Cow<'static, [HeaderName]>>,
-    hyper: HyperClient,
+    hyper: HyperClient<Connector, super::Body>,
     redirect: redirect::Policy,
     redirect_with_proxy_auth: bool,
     referer: bool,


### PR DESCRIPTION
This pull request focuses on refactoring the `ClientBuilder` and `Config` structures in the `src/client/http.rs` file to improve the handling of TLS configurations and headers. The most important changes include the introduction of a `TlsConfig` structure, removal of the `HttpContext` structure, and updates to various methods to reflect these changes.

Refactoring and improvements:

* Replaced `HttpContext` with `TlsConfig` in `Config` struct and `ClientBuilder` methods. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L124-R126) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L167-R176) [[3]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L196-R200)
* Added `headers` and `headers_order` fields to `Config` struct and updated related methods to use these fields. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90R94-R95) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90R143-R144) [[3]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L340-R327)
* Updated `ClientBuilder` methods to use the new `TlsConfig` structure for TLS-related configurations. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L775-R761) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L994-R997) [[3]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1081-R1076)
* Simplified the `impersonate` method to update the `Config` struct directly with values from the `HttpContextProvider`.
* Removed unnecessary imports and updated existing imports to reflect the refactoring changes. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L26-R31) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L41-R41)