### PR TITLE
fix: Ensure HTTP version negotiation for non-TLS requests

### DIFF
--- a/examples/request_with_version.rs
+++ b/examples/request_with_version.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), rquest::Error> {
         .send()
         .await?;
 
-    println!("{:?}", resp.version());
+    assert_eq!(resp.version(), Version::HTTP_11);
     println!("{}", resp.text().await?);
 
     Ok(())

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -195,7 +195,7 @@ impl Dst {
 
     #[inline(always)]
     pub(crate) fn is_h2(&self) -> bool {
-        self.alpn_protos.map_or(false, |a| a == AlpnProtos::Http2)
+        self.alpn_protos == Some(AlpnProtos::Http2)
     }
 
     #[inline(always)]

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -177,32 +177,32 @@ impl Dst {
             .map_err(|_| e!(UserAbsoluteUriRequired))
     }
 
-    /// Get the URI
     #[inline(always)]
     pub(crate) fn uri(&self) -> &Uri {
         &self.inner.uri
     }
 
-    /// Set the next destination of the request (for proxy)
     #[inline(always)]
     pub(crate) fn set_uri(&mut self, mut uri: Uri) {
         let inner = Arc::make_mut(&mut self.inner);
         std::mem::swap(&mut inner.uri, &mut uri);
     }
 
-    /// Get the alpn protos
     #[inline(always)]
     pub(crate) fn alpn_protos(&self) -> Option<AlpnProtos> {
         self.alpn_protos
     }
 
-    /// Take network scheme for iface
+    #[inline(always)]
+    pub(crate) fn is_h2(&self) -> bool {
+        self.alpn_protos.map_or(false, |a| a == AlpnProtos::Http2)
+    }
+
     #[inline(always)]
     pub(crate) fn take_addresses(&mut self) -> (Option<Ipv4Addr>, Option<Ipv6Addr>) {
         Arc::make_mut(&mut self.inner).network.take_addresses()
     }
 
-    /// Take the network scheme for iface
     #[inline(always)]
     pub(crate) fn take_interface(&mut self) -> Option<std::borrow::Cow<'static, str>> {
         cfg_bindable_device! {
@@ -212,7 +212,6 @@ impl Dst {
         cfg_non_bindable_device!(None)
     }
 
-    /// Take the network scheme for proxy
     #[inline(always)]
     pub(crate) fn take_proxy_scheme(&mut self) -> Option<ProxyScheme> {
         Arc::make_mut(&mut self.inner).network.take_proxy_scheme()
@@ -325,7 +324,7 @@ where
     /// # fn main() {}
     /// ```
     pub fn request(&self, req: InnerRequest<B>) -> ResponseFuture {
-        let (mut req, network_scheme, http_version_pref) = req.pieces();
+        let (mut req, network_scheme, alpn_protos) = req.pieces();
         let is_http_connect = req.method() == Method::CONNECT;
         match req.version() {
             Version::HTTP_10 => {
@@ -339,12 +338,7 @@ where
             other => return ResponseFuture::error_version(other),
         };
 
-        let ctx = match Dst::new(
-            req.uri_mut(),
-            is_http_connect,
-            network_scheme,
-            http_version_pref,
-        ) {
+        let ctx = match Dst::new(req.uri_mut(), is_http_connect, network_scheme, alpn_protos) {
             Ok(s) => s,
             Err(err) => {
                 return ResponseFuture::new(future::err(err));
@@ -619,7 +613,11 @@ where
 
         let h1_builder = self.h1_builder.clone();
         let h2_builder = self.h2_builder.clone();
-        let ver = self.config.ver;
+        let ver = if dst.is_h2() {
+            Ver::Http2
+        } else {
+            self.config.ver
+        };
         let is_ver_h2 = ver == Ver::Http2;
         let connector = self.connector.clone();
         hyper_lazy(move || {


### PR DESCRIPTION
This pull request includes changes to improve HTTP version handling and testing in the `rquest` library. The most important changes include modifying the request version handling, adding new tests for HTTP versions, and removing outdated tests.

Improvements to HTTP version handling:

* [`examples/request_with_version.rs`](diffhunk://#diff-619e2fef0362bd5ed01b80b7abf650e69b24e30d46c69646fd4bebee4fdfe3aeL22-R22): Replaced `println!("{:?}", resp.version());` with `assert_eq!(resp.version(), Version::HTTP_11);` to ensure the response version is HTTP/1.1.
* [`src/util/client/mod.rs`](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL180-L205): Added `is_h2` method to check if the ALPN protocol is HTTP/2, and updated the `request` method to handle ALPN protocols correctly. [[1]](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL180-L205) [[2]](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL328-R327) [[3]](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL342-R341) [[4]](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL622-R620)

Testing improvements:

* [`tests/client.rs`](diffhunk://#diff-883b589a25e7f6433759649381f7f19ba2c03a1cc5d67d9454ed55136073deddR513-R559): Added new tests `default_http_version`, `http1_version`, and `http2_version` to validate the handling of different HTTP versions.
* [`tests/client.rs`](diffhunk://#diff-883b589a25e7f6433759649381f7f19ba2c03a1cc5d67d9454ed55136073deddL325-L343): Removed the outdated `http2_upgrade` test that required TLS support in the test server.

Code cleanup:

* [`tests/client.rs`](diffhunk://#diff-883b589a25e7f6433759649381f7f19ba2c03a1cc5d67d9454ed55136073deddL6-R9): Updated imports to include `Version` from the `http` crate.

close: https://github.com/0x676e67/rquest/issues/392