### PR TITLE
refactor: Replace unsafe methods with safe methods in `ConnectConfiguration`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ tokio = { version = "1", default-features = false, features = ["net","time"] }
 pin-project-lite = "0.2.0"
 ipnet = "2.11.0"
 
-# hyper util
+## util
 socket2 = { version = "0.5", features = ["all"] }
 lru = { version = "0.13", default-features = false }
 
@@ -112,10 +112,9 @@ lru = { version = "0.13", default-features = false }
 boring2 = { version = "4.15.1", features = ["pq-experimental"] }
 boring-sys2 = { version = "4.15.1", features = ["pq-experimental"] }
 tokio-boring2 = { version = "4.15.1", features = ["pq-experimental"] }
-foreign-types = "0.5.0"
 linked_hash_set = "0.1"
 
-# cert compression
+## cert compression
 brotli = "7"
 flate2 = "1"
 zstd = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,9 @@ socket2 = { version = "0.5", features = ["all"] }
 lru = { version = "0.13", default-features = false }
 
 ## boring-tls
-boring2 = { version = "4.15.0", features = ["pq-experimental"] }
-boring-sys2 = { version = "4.15.0", features = ["pq-experimental"] }
-tokio-boring2 = { version = "4.15.0", features = ["pq-experimental"] }
+boring2 = { version = "4.15.1", features = ["pq-experimental"] }
+boring-sys2 = { version = "4.15.1", features = ["pq-experimental"] }
+tokio-boring2 = { version = "4.15.1", features = ["pq-experimental"] }
 foreign-types = "0.5.0"
 linked_hash_set = "0.1"
 

--- a/src/tls/cert/mod.rs
+++ b/src/tls/cert/mod.rs
@@ -5,7 +5,6 @@ mod load;
 use super::{sv_handler, TlsResult};
 use boring2::{ssl::SslConnectorBuilder, x509::store::X509Store};
 use boring_sys2 as ffi;
-use foreign_types::ForeignTypeRef;
 
 /// The root certificate store.
 #[allow(missing_debug_implementations)]
@@ -38,7 +37,7 @@ impl RootCertStore {
                         sv_handler(unsafe {
                             ffi::SSL_CTX_set1_verify_cert_store(
                                 builder.as_ptr(),
-                                cert_store.as_ptr(),
+                                cert_store as *const _ as *mut _,
                             )
                         })?;
                     } else {
@@ -58,7 +57,7 @@ impl RootCertStore {
             }
             RootCertStore::Borrowed(cert_store) => {
                 sv_handler(unsafe {
-                    ffi::SSL_CTX_set1_verify_cert_store(builder.as_ptr(), cert_store.as_ptr())
+                    ffi::SSL_CTX_set1_verify_cert_store(builder.as_ptr(), cert_store as *const _ as *mut _)
                 })?;
             }
         }

--- a/src/tls/cert/mod.rs
+++ b/src/tls/cert/mod.rs
@@ -57,7 +57,10 @@ impl RootCertStore {
             }
             RootCertStore::Borrowed(cert_store) => {
                 sv_handler(unsafe {
-                    ffi::SSL_CTX_set1_verify_cert_store(builder.as_ptr(), cert_store as *const _ as *mut _)
+                    ffi::SSL_CTX_set1_verify_cert_store(
+                        builder.as_ptr(),
+                        cert_store as *const _ as *mut _,
+                    )
                 })?;
             }
         }

--- a/src/tls/conn/layer.rs
+++ b/src/tls/conn/layer.rs
@@ -131,14 +131,14 @@ impl HttpsLayer {
         };
 
         let callback = Arc::new(move |conf: &mut ConnectConfiguration, _: &Uri| {
-            // Set ECH grease
-            conf.enable_ech_grease(settings.enable_ech_grease)?;
-
             // Use server name indication
             conf.set_use_server_name_indication(settings.tls_sni);
 
             // Verify hostname
             conf.set_verify_hostname(settings.verify_hostname);
+
+            // Set ECH grease
+            conf.set_enable_ech_grease(settings.enable_ech_grease);
 
             // Set ALPS
             conf.alps_protos(settings.alps_protos, settings.alps_use_new_codepoint)?;

--- a/src/tls/ext.rs
+++ b/src/tls/ext.rs
@@ -42,9 +42,6 @@ pub trait SslRefExt {
 
 /// ConnectConfigurationExt trait for `ConnectConfiguration`.
 pub trait ConnectConfigurationExt {
-    /// Configure the enable_ech_grease for the given `ConnectConfiguration`.
-    fn enable_ech_grease(&mut self, enable: bool) -> TlsResult<&mut ConnectConfiguration>;
-
     /// Configure the ALPS for the given `ConnectConfiguration`.
     fn alps_protos(
         &mut self,
@@ -114,15 +111,6 @@ impl SslConnectorBuilderExt for SslConnectorBuilder {
 }
 
 impl ConnectConfigurationExt for ConnectConfiguration {
-    #[inline]
-    fn enable_ech_grease(&mut self, enable: bool) -> TlsResult<&mut ConnectConfiguration> {
-        if enable {
-            self.set_enable_ech_grease(enable);
-        }
-
-        Ok(self)
-    }
-
     #[inline]
     fn alps_protos(
         &mut self,

--- a/src/tls/ext.rs
+++ b/src/tls/ext.rs
@@ -3,7 +3,6 @@ use super::{sv_handler, AlpnProtos, AlpsProtos, TlsResult, TlsVersion};
 
 use boring2::ssl::{ConnectConfiguration, SslConnectorBuilder, SslOptions, SslRef, SslVerifyMode};
 use boring_sys2 as ffi;
-use foreign_types::ForeignTypeRef;
 
 /// SslConnectorBuilderExt trait for `SslConnectorBuilder`.
 pub trait SslConnectorBuilderExt {

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -176,16 +176,6 @@ impl AlpsProtos {
     pub const HTTP1: AlpsProtos = AlpsProtos(b"http/1.1");
     /// Application Settings protocol for HTTP/2
     pub const HTTP2: AlpsProtos = AlpsProtos(b"h2");
-
-    #[inline(always)]
-    pub(crate) fn as_ptr(&self) -> *const u8 {
-        self.0.as_ptr()
-    }
-
-    #[inline(always)]
-    pub(crate) fn len(&self) -> usize {
-        self.0.len()
-    }
 }
 
 /// Hyper extension carrying extra TLS layer information.


### PR DESCRIPTION
This pull request includes several updates and refactorings to the `Cargo.toml` and `src/tls` files. The main changes involve updating dependencies and refactoring the code to remove unsafe blocks and improve readability.

Dependency Updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L112-R114): Updated the `boring2`, `boring-sys2`, and `tokio-boring2` dependencies from version `4.15.0` to `4.15.1`.

Code Refactoring:

* [`src/tls/ext.rs`](diffhunk://#diff-8ea4f8c12a8a50293cee375c2af8cf7aa873af6e6dc534da267b2904b7237836L4-R4): Added `SslOptions` to the import statement from `boring2::ssl`.
* [`src/tls/ext.rs`](diffhunk://#diff-8ea4f8c12a8a50293cee375c2af8cf7aa873af6e6dc534da267b2904b7237836L120-R123): Refactored the `enable_ech_grease` method to remove the unsafe block and use the `set_enable_ech_grease` method directly.
* [`src/tls/ext.rs`](diffhunk://#diff-8ea4f8c12a8a50293cee375c2af8cf7aa873af6e6dc534da267b2904b7237836L131-R137): Refactored the `add_application_settings` method to remove the unsafe block and use the `set_alps_use_new_codepoint` method directly.
* [`src/tls/ext.rs`](diffhunk://#diff-8ea4f8c12a8a50293cee375c2af8cf7aa873af6e6dc534da267b2904b7237836L153-R146): Refactored the `skip_session_ticket` method to remove the unsafe block and use the `set_options` method with `SslOptions::NO_TICKET`.

Removal of Unused Methods:

* [`src/tls/mod.rs`](diffhunk://#diff-2fe8ca04c205b0602c61e6dba683c0cc68c15f1ddb0009207d5ae78045831a4cL179-L188): Removed the `as_ptr` and `len` methods from the `AlpsProtos` implementation as they are no longer needed.