### PR TITLE
chore(client): rename client builder http2 timer name from `timer` to `http2_timer`

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -224,7 +224,7 @@ impl ClientBuilder {
         config
             .builder
             .http2_only(http2_only)
-            .timer(TokioTimer::new())
+            .http2_timer(TokioTimer::new())
             .pool_timer(TokioTimer::new())
             .pool_idle_timeout(config.pool_idle_timeout)
             .pool_max_idle_per_host(config.pool_max_idle_per_host)

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -1166,13 +1166,13 @@ impl Builder {
         self
     }
 
-    /// Provide a timer to be used for h2
+    /// Provide a timer to be used for http2
     ///
-    /// See the documentation of [`h2::client::Builder::timer`] for more
+    /// See the documentation of [`http2::client::Builder::timer`] for more
     /// details.
     ///
-    /// [`h2::client::Builder::timer`]: https://docs.rs/h2/client/struct.Builder.html#method.timer
-    pub fn timer<M>(&mut self, timer: M) -> &mut Self
+    /// [`http2::client::Builder::timer`]: https://docs.rs/http2/latest/http2/client/struct.Builder.html#method.timer
+    pub fn http2_timer<M>(&mut self, timer: M) -> &mut Self
     where
         M: Timer + Send + Sync + 'static,
     {


### PR DESCRIPTION
This pull request includes changes to improve the naming consistency for HTTP/2 timer methods and documentation in the `src/client/http.rs` and `src/util/client/mod.rs` files. The most important changes include renaming the timer method and updating related documentation references.

Improvements to naming consistency:

* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L227-R227): Renamed the `timer` method to `http2_timer` to reflect its purpose more clearly.
* [`src/util/client/mod.rs`](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL1169-R1175): Updated the method name from `timer` to `http2_timer` and modified the associated documentation to use `http2` instead of `h2`, ensuring consistency with the new naming convention.