### PR TITLE
perf(connect): Delay connector layer initialization to improve performance

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1195,7 +1195,7 @@ impl ClientBuilder {
         let layer = BoxCloneSyncServiceLayer::new(layer);
         self.config
             .connector_layers
-            .get_or_insert_default()
+            .get_or_insert_with(Vec::new)
             .push(layer);
         self
     }

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1362,7 +1362,7 @@ impl Client {
         }
 
         #[cfg(feature = "cookies")]
-        let cookie_store = _cookie_store.as_ref().or(inner.cookie_store.as_ref());
+        let cookie_store = _cookie_store.as_ref().or(client.cookie_store.as_ref());
 
         // Add cookies from the cookie store.
         #[cfg(feature = "cookies")]

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -122,7 +122,7 @@ struct Config {
     https_only: bool,
     http2_max_retry_count: usize,
     tls_info: bool,
-    connector_layers: Vec<BoxedConnectorLayer>,
+    connector_layers: Option<Vec<BoxedConnectorLayer>>,
     builder: Builder,
     tls_config: TlsConfig,
 }
@@ -195,7 +195,7 @@ impl ClientBuilder {
                 https_only: false,
                 http2_max_retry_count: 2,
                 tls_info: false,
-                connector_layers: Vec::new(),
+                connector_layers: None,
                 tls_config: TlsConfig::default(),
             },
         }
@@ -1193,7 +1193,10 @@ impl ClientBuilder {
         <L::Service as Service<Unnameable>>::Future: Send + 'static,
     {
         let layer = BoxCloneSyncServiceLayer::new(layer);
-        self.config.connector_layers.push(layer);
+        self.config
+            .connector_layers
+            .get_or_insert_default()
+            .push(layer);
         self
     }
 }


### PR DESCRIPTION
Change the initialization of `connector_layers` to lazy initialization when used to avoid initialization when not necessary, thereby optimizing performance.

- Modify the `connector_layer` method of `ClientBuilder` so that it initializes `connector_layers` only when it is called for the first time.
- In this way, unnecessary memory allocation and initialization operations are reduced, improving performance.