### PR TITLE
docs(client): Update client `cloned` method documentation

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1502,6 +1502,7 @@ impl Client {
     /// This method creates a new instance of the `Client` by cloning its internal state.
     /// The cloned client will have the same configuration and state as the original client,
     /// but it will be a separate instance that can be used independently.
+    /// Note that this will still share the connection pool with the original `Client`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
This pull request includes a minor documentation update to the `Client` implementation in the `src/client/http.rs` file. The change adds a note about the connection pool sharing behavior when cloning a `Client` instance.

Documentation update:

* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90R1505): Added a note to the `Client` documentation indicating that the cloned client will share the connection pool with the original `Client`.