### PR TITLE
build(deps): macOS platform dependencies are minimized as much as possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["webpki-roots", "charset"]
+default = ["webpki-roots", "charset", "macos-system-configuration"]
 
 full = [
     "json",
@@ -60,7 +60,11 @@ stream = ["tokio/fs", "dep:tokio-util"]
 socks = ["dep:tokio-socks"]
 
 native-roots = ["dep:rustls-native-certs"]
+
 webpki-roots = ["dep:webpki-root-certs"]
+
+# Use the system's proxy configuration.
+macos-system-configuration = ["dep:system-configuration"]
 
 # Optional enable http2 tracing
 http2-tracing = ["hyper2/http2-tracing"]
@@ -146,7 +150,7 @@ hickory-resolver = { version = "0.24", optional = true }
 windows-registry = "0.4.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-system-configuration = "0.6.0"
+system-configuration = { version = "0.6.0", optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "visionos", target_os = "macos", target_os = "tvos", target_os = "watchos"))'.dependencies]
 libc = "0.2"

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::env;
 use std::error::Error;
 use std::net::IpAddr;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 use system_configuration::{
     core_foundation::{
         base::CFType,
@@ -963,7 +963,7 @@ fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     Ok((proxy_enable == 1).then_some(proxy_server))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 fn parse_setting_from_dynamic_store(
     proxies_map: &CFDictionary<CFString, CFType>,
     enabled_key: CFStringRef,
@@ -1001,7 +1001,7 @@ fn parse_setting_from_dynamic_store(
     None
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     let store = SCDynamicStoreBuilder::new("rquest").build();
 
@@ -1032,12 +1032,18 @@ fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(
+    target_os = "windows",
+    all(target_os = "macos", feature = "macos-system-configuration")
+))]
 fn get_from_platform() -> Option<String> {
     get_from_platform_impl().ok().flatten()
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(
+    target_os = "windows",
+    all(target_os = "macos", feature = "macos-system-configuration")
+)))]
 fn get_from_platform() -> Option<String> {
     None
 }


### PR DESCRIPTION
This pull request introduces several changes to add support for macOS system configuration as an optional feature. The most important changes include modifications to the `Cargo.toml` file to define the new feature and updates to the `src/proxy.rs` file to conditionally compile code based on the feature flag.

### Feature addition in `Cargo.toml`:

* Added `macos-system-configuration` to the default features list.
* Defined the `macos-system-configuration` feature to use the `system-configuration` dependency.
* Marked the `system-configuration` dependency as optional for macOS targets.

### Conditional compilation in `src/proxy.rs`:

* Updated the import statement for `system_configuration` to be conditional on the `macos-system-configuration` feature.
* Modified the `parse_setting_from_dynamic_store` and `get_from_platform_impl` functions to conditionally compile based on the `macos-system-configuration` feature. [[1]](diffhunk://#diff-48b095c28162eadb826d4f3529ba6e44368efa69859fa418868f1776321ac686L966-R966) [[2]](diffhunk://#diff-48b095c28162eadb826d4f3529ba6e44368efa69859fa418868f1776321ac686L1004-R1004)
* Adjusted the `get_from_platform` function to include the feature flag in its conditional compilation.