### PR TITLE
build(deps): Apple platform dependencies are minimized as much as possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["webpki-roots", "charset"]
+default = ["webpki-roots", "charset", "macos-system-configuration"]
 
 full = [
     "json",
@@ -60,7 +60,11 @@ stream = ["tokio/fs", "dep:tokio-util"]
 socks = ["dep:tokio-socks"]
 
 native-roots = ["dep:rustls-native-certs"]
+
 webpki-roots = ["dep:webpki-root-certs"]
+
+# Use the system's proxy configuration.
+macos-system-configuration = ["dep:system-configuration"]
 
 # Optional enable http2 tracing
 http2-tracing = ["hyper2/http2-tracing"]
@@ -146,7 +150,7 @@ hickory-resolver = { version = "0.24", optional = true }
 windows-registry = "0.4.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-system-configuration = "0.6.0"
+system-configuration = { version = "0.6.0", optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "visionos", target_os = "macos", target_os = "tvos", target_os = "watchos"))'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ webpki-roots = ["dep:webpki-root-certs"]
 # Use the system's proxy configuration.
 macos-system-configuration = ["dep:system-configuration"]
 
+# Use the Apple platform's network device binding.
+apple-bindable-device = ["dep:libc"]
+
 # Optional enable http2 tracing
 http2-tracing = ["hyper2/http2-tracing"]
 
@@ -153,7 +156,7 @@ windows-registry = "0.4.0"
 system-configuration = { version = "0.6.0", optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "visionos", target_os = "macos", target_os = "tvos", target_os = "watchos"))'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 hyper = { version = "1.1.0", default-features = false, features = [
@@ -308,6 +311,7 @@ required-features = ["websocket", "http2-tracing", "futures-util/std"]
 [[example]]
 name = "client_chain"
 path = "examples/client_chain.rs"
+required-features = ["apple-bindable-device"]
 
 [[example]]
 name = "request_with_redirect"

--- a/examples/client_chain.rs
+++ b/examples/client_chain.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), rquest::Error> {
         .as_mut()
         .impersonate(Impersonate::Safari18)
         .headers_order(HEADER_ORDER)
-        .interface("utun4")
+        .interface("utun6")
         .apply()?;
 
     let text = client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,11 +286,16 @@ macro_rules! cfg_bindable_device {
             target_os = "android",
             target_os = "fuchsia",
             target_os = "linux",
-            target_os = "ios",
-            target_os = "visionos",
-            target_os = "macos",
-            target_os = "tvos",
-            target_os = "watchos"
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
         ))]
         $(
             $tt
@@ -306,11 +311,16 @@ macro_rules! cfg_non_bindable_device {
             target_os = "android",
             target_os = "fuchsia",
             target_os = "linux",
-            target_os = "ios",
-            target_os = "visionos",
-            target_os = "macos",
-            target_os = "tvos",
-            target_os = "watchos"
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
         )))]
         $(
             $tt

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::env;
 use std::error::Error;
 use std::net::IpAddr;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 use system_configuration::{
     core_foundation::{
         base::CFType,
@@ -963,7 +963,7 @@ fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     Ok((proxy_enable == 1).then_some(proxy_server))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 fn parse_setting_from_dynamic_store(
     proxies_map: &CFDictionary<CFString, CFType>,
     enabled_key: CFStringRef,
@@ -1001,7 +1001,7 @@ fn parse_setting_from_dynamic_store(
     None
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     let store = SCDynamicStoreBuilder::new("rquest").build();
 
@@ -1032,12 +1032,18 @@ fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(
+    target_os = "windows",
+    all(target_os = "macos", feature = "macos-system-configuration")
+))]
 fn get_from_platform() -> Option<String> {
     get_from_platform_impl().ok().flatten()
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(
+    target_os = "windows",
+    all(target_os = "macos", feature = "macos-system-configuration")
+)))]
 fn get_from_platform() -> Option<String> {
     None
 }

--- a/src/util/client/connect/http.rs
+++ b/src/util/client/connect/http.rs
@@ -812,12 +812,15 @@ fn connect(
             .map_err(ConnectError::m("tcp bind interface error"))?;
     }
 
-    #[cfg(any(
-        target_os = "ios",
-        target_os = "visionos",
-        target_os = "macos",
-        target_os = "tvos",
-        target_os = "watchos",
+    #[cfg(all(
+        feature = "apple-bindable-device",
+        any(
+            target_os = "ios",
+            target_os = "visionos",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos",
+        )
     ))]
     /// That this only supports ios, visionos, macos, tvos, watchos
     if let Some(interface) = &config.interface {

--- a/src/util/client/connect/http.rs
+++ b/src/util/client/connect/http.rs
@@ -81,11 +81,16 @@ struct Config {
         target_os = "android",
         target_os = "fuchsia",
         target_os = "linux",
-        target_os = "ios",
-        target_os = "visionos",
-        target_os = "macos",
-        target_os = "tvos",
-        target_os = "watchos",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
     ))]
     interface: Option<std::borrow::Cow<'static, str>>,
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
@@ -246,11 +251,16 @@ impl<R> HttpConnector<R> {
                     target_os = "android",
                     target_os = "fuchsia",
                     target_os = "linux",
-                    target_os = "ios",
-                    target_os = "visionos",
-                    target_os = "macos",
-                    target_os = "tvos",
-                    target_os = "watchos",
+                    all(
+                        feature = "apple-bindable-device",
+                        any(
+                            target_os = "ios",
+                            target_os = "visionos",
+                            target_os = "macos",
+                            target_os = "tvos",
+                            target_os = "watchos",
+                        )
+                    )
                 ))]
                 interface: None,
                 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]


### PR DESCRIPTION
This pull request introduces a new feature for supporting Apple platform's network device binding and includes several related changes across multiple files. The most important changes are listed below:

### Dependency Management:

* Added `apple-bindable-device` dependency to `Cargo.toml` to enable the new feature for Apple platforms.
* Made the `libc` dependency optional for Apple platforms in `Cargo.toml`.

### Feature Configuration:

* Updated the `required-features` for the `client_chain` example to include the new `apple-bindable-device` feature in `Cargo.toml`.

### Code Modifications:

* Changed the network interface from `"utun4"` to `"utun6"` in the `client_chain.rs` example to reflect the new feature.
* Updated the `cfg_bindable_device` and `cfg_non_bindable_device` macros in `src/lib.rs` to conditionally include the new feature for Apple platforms. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R289-R298) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R314-R323)
* Modified the `connect` function in `src/util/client/connect/http.rs` to support the new feature for Apple platforms.