### PR TITLE
build: Visualize macro conditional compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,13 +132,8 @@ cookie_crate = { version = "0.18", package = "cookie", optional = true }
 cookie_store = { version = "0.21", optional = true }
 
 ## compression
-async-compression = { version = "0.4.0", default-features = false, features = [
-    "tokio",
-], optional = true }
-tokio-util = { version = "0.7.0", default-features = false, features = [
-    "codec",
-    "io",
-], optional = true }
+async-compression = { version = "0.4.0", default-features = false, features = ["tokio"], optional = true }
+tokio-util = { version = "0.7.0", default-features = false, features = ["codec","io"], optional = true }
 
 ## socks
 tokio-socks = { version = "0.5.2", optional = true }
@@ -175,8 +170,8 @@ hyper-util = { version = "0.1.10", features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 libflate = "2.0.0"
-zstd = { version = "0.13" }
-brotli = { version = "7.0.0" }
+zstd = "0.13"
+brotli = "7.0.0"
 doc-comment = "0.3"
 tokio = { version = "1.0", default-features = false, features = [
     "macros",

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -28,7 +28,7 @@ use crate::util::{
     },
     rt::{tokio::TokioTimer, TokioExecutor},
 };
-use crate::{cfg_bindable_device, error, impl_debug, Http1Config, Http2Config, TlsConfig};
+use crate::{error, impl_debug, Http1Config, Http2Config, TlsConfig};
 use crate::{
     redirect,
     tls::{AlpnProtos, BoringTlsConnector, RootCertStore, TlsVersion},
@@ -853,24 +853,38 @@ impl ClientBuilder {
         self
     }
 
-    cfg_bindable_device! {
-        /// Bind to an interface by `SO_BINDTODEVICE`.
-        ///
-        /// # Example
-        ///
-        /// ```
-        /// let interface = "lo";
-        /// let client = rquest::Client::builder()
-        ///     .interface(interface)
-        ///     .build().unwrap();
-        /// ```
-        pub fn interface<T>(mut self, interface: T) -> ClientBuilder
-        where
-            T: Into<Cow<'static, str>>,
-        {
-            self.config.network_scheme.interface(interface);
-            self
-        }
+    /// Bind to an interface by `SO_BINDTODEVICE`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let interface = "lo";
+    /// let client = rquest::Client::builder()
+    ///     .interface(interface)
+    ///     .build().unwrap();
+    /// ```
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
+    #[cfg_attr(docsrs, feature = "apple-bindable-device")]
+    pub fn interface<T>(mut self, interface: T) -> ClientBuilder
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.config.network_scheme.interface(interface);
+        self
     }
 
     /// Set that all sockets have `SO_KEEPALIVE` set with the supplied duration.
@@ -1784,16 +1798,29 @@ impl<'c> ClientMut<'c> {
         self
     }
 
-    cfg_bindable_device! {
-        /// Bind to an interface by `SO_BINDTODEVICE`.
-        #[inline]
-        pub fn interface<T>(mut self, interface: T)  -> ClientMut<'c>
-        where
-            T: Into<Cow<'static, str>>,
-        {
-            self.inner_ref.network_scheme.interface(interface);
-            self
-        }
+    /// Bind to an interface by `SO_BINDTODEVICE`.
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
+    #[inline]
+    pub fn interface<T>(mut self, interface: T) -> ClientMut<'c>
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.inner_ref.network_scheme.interface(interface);
+        self
     }
 
     /// Sets the proxies for this client in a thread-safe manner and returns the old proxies.

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -16,7 +16,7 @@ use super::response::Response;
 use crate::cookie;
 use crate::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use crate::util::client::{NetworkScheme, NetworkSchemeBuilder};
-use crate::{cfg_bindable_device, redirect, IntoUrl, Method, Proxy, Url};
+use crate::{redirect, IntoUrl, Method, Proxy, Url};
 #[cfg(feature = "cookies")]
 use std::sync::Arc;
 
@@ -579,17 +579,31 @@ impl RequestBuilder {
         self
     }
 
-    cfg_bindable_device! {
-        /// Set the interface for this request.
-        pub fn interface<I>(mut self, interface: I) -> RequestBuilder
-        where
-            I: Into<std::borrow::Cow<'static, str>>,
-        {
-            if let Ok(ref mut req) = self.request {
-                req.network_scheme.interface(interface);
-            }
-            self
+    /// Set the interface for this request.
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
+    #[cfg_attr(docsrs, feature = "apple-bindable-device")]
+    pub fn interface<I>(mut self, interface: I) -> RequestBuilder
+    where
+        I: Into<std::borrow::Cow<'static, str>>,
+    {
+        if let Ok(ref mut req) = self.request {
+            req.network_scheme.interface(interface);
         }
+        self
     }
 
     /// Set the cookie store for this request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,56 +278,6 @@ macro_rules! impl_debug {
     }
 }
 
-/// Macro to conditionally compile code for bindable devices.
-#[macro_export]
-macro_rules! cfg_bindable_device {
-    ($($tt:tt)*) => {
-        #[cfg(any(
-            target_os = "android",
-            target_os = "fuchsia",
-            target_os = "linux",
-            all(
-                feature = "apple-bindable-device",
-                any(
-                    target_os = "ios",
-                    target_os = "visionos",
-                    target_os = "macos",
-                    target_os = "tvos",
-                    target_os = "watchos",
-                )
-            )
-        ))]
-        $(
-            $tt
-        )*
-    };
-}
-
-/// Macro to conditionally compile code for non-bindable devices.
-#[macro_export]
-macro_rules! cfg_non_bindable_device {
-    ($($tt:tt)*) => {
-        #[cfg(not(any(
-            target_os = "android",
-            target_os = "fuchsia",
-            target_os = "linux",
-            all(
-                feature = "apple-bindable-device",
-                any(
-                    target_os = "ios",
-                    target_os = "visionos",
-                    target_os = "macos",
-                    target_os = "tvos",
-                    target_os = "watchos",
-                )
-            )
-        )))]
-        $(
-            $tt
-        )*
-    }
-}
-
 /// Shortcut method to quickly make a `GET` request.
 ///
 /// See also the methods on the [`rquest::Response`](./struct.Response.html)

--- a/src/tls/conn/mod.rs
+++ b/src/tls/conn/mod.rs
@@ -6,7 +6,6 @@ mod layer;
 
 pub use self::layer::*;
 use super::BoringTlsConnector;
-use crate::cfg_bindable_device;
 use crate::connect::HttpConnector;
 use crate::tls::ext::SslRefExt;
 use crate::tls::{AlpnProtos, AlpsProtos, TlsResult};
@@ -65,9 +64,22 @@ impl HttpsConnectorBuilder {
     #[inline]
     #[allow(unused_mut)]
     pub fn interface(mut self, _interface: Option<Cow<'static, str>>) -> Self {
-        cfg_bindable_device! {
-            self.http.set_interface(_interface);
-        }
+        #[cfg(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
+        ))]
+        self.http.set_interface(_interface);
         self
     }
 

--- a/src/util/client/connect/http.rs
+++ b/src/util/client/connect/http.rs
@@ -19,7 +19,6 @@ use tokio::time::Sleep;
 
 use super::dns::{self, resolve, GaiResolver, Resolve};
 use super::{Connected, Connection};
-use crate::cfg_bindable_device;
 use crate::util::rt::TokioIo;
 
 /// A connector for the `http` scheme.
@@ -400,15 +399,28 @@ impl<R> HttpConnector<R> {
     /// This function is only available on Android、Fuchsia、Linux and Apple platforms.
     ///
     /// [VRF]: https://www.kernel.org/doc/Documentation/networking/vrf.txt
-    cfg_bindable_device! {
-        #[inline]
-        pub fn set_interface<S>(&mut self, interface: S) -> &mut Self
-        where
-            S: Into<Option<std::borrow::Cow<'static, str>>>,
-        {
-            self.config_mut().interface = interface.into();
-            self
-        }
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
+    #[inline]
+    pub fn set_interface<S>(&mut self, interface: S) -> &mut Self
+    where
+        S: Into<Option<std::borrow::Cow<'static, str>>>,
+    {
+        self.config_mut().interface = interface.into();
+        self
     }
 
     /// Sets the value of the TCP_USER_TIMEOUT option on the socket.

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -34,7 +34,7 @@ use sync_wrapper::SyncWrapper;
 
 use crate::proxy::ProxyScheme;
 use crate::util::common;
-use crate::{cfg_bindable_device, cfg_non_bindable_device, impl_debug, AlpnProtos};
+use crate::{impl_debug, AlpnProtos};
 use connect::capture::CaptureConnectionExtension;
 use connect::{Alpn, Connect, Connected, Connection};
 use pool::Ver;
@@ -200,11 +200,41 @@ impl Dst {
 
     #[inline(always)]
     pub(crate) fn take_interface(&mut self) -> Option<std::borrow::Cow<'static, str>> {
-        cfg_bindable_device! {
+        #[cfg(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
+        ))]
+        {
             Arc::make_mut(&mut self.inner).network.take_interface()
         }
 
-        cfg_non_bindable_device!(None)
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
+        )))]
+        None
     }
 
     #[inline(always)]

--- a/src/util/client/network.rs
+++ b/src/util/client/network.rs
@@ -106,22 +106,22 @@ impl NetworkScheme {
 
 impl fmt::Debug for NetworkScheme {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        #[cfg(any(
-            target_os = "android",
-            target_os = "fuchsia",
-            target_os = "linux",
-            all(
-                feature = "apple-bindable-device",
-                any(
-                    target_os = "ios",
-                    target_os = "visionos",
-                    target_os = "macos",
-                    target_os = "tvos",
-                    target_os = "watchos",
-                )
-            )
-        ))]
         match self {
+            #[cfg(any(
+                target_os = "android",
+                target_os = "fuchsia",
+                target_os = "linux",
+                all(
+                    feature = "apple-bindable-device",
+                    any(
+                        target_os = "ios",
+                        target_os = "visionos",
+                        target_os = "macos",
+                        target_os = "tvos",
+                        target_os = "watchos",
+                    )
+                )
+            ))]
             NetworkScheme::Scheme {
                 interface,
                 addresses,
@@ -151,27 +151,21 @@ impl fmt::Debug for NetworkScheme {
 
                 write!(f, "}}")
             }
-            NetworkScheme::Default => {
-                write!(f, "default")
-            }
-        }
-
-        #[cfg(not(any(
-            target_os = "android",
-            target_os = "fuchsia",
-            target_os = "linux",
-            all(
-                feature = "apple-bindable-device",
-                any(
-                    target_os = "ios",
-                    target_os = "visionos",
-                    target_os = "macos",
-                    target_os = "tvos",
-                    target_os = "watchos",
+            #[cfg(not(any(
+                target_os = "android",
+                target_os = "fuchsia",
+                target_os = "linux",
+                all(
+                    feature = "apple-bindable-device",
+                    any(
+                        target_os = "ios",
+                        target_os = "visionos",
+                        target_os = "macos",
+                        target_os = "tvos",
+                        target_os = "watchos",
+                    )
                 )
-            )
-        )))]
-        match self {
+            )))]
             NetworkScheme::Scheme {
                 addresses,
                 proxy_scheme,
@@ -277,61 +271,62 @@ impl NetworkSchemeBuilder {
         self
     }
 
-    #[cfg(any(
-        target_os = "android",
-        target_os = "fuchsia",
-        target_os = "linux",
-        all(
-            feature = "apple-bindable-device",
-            any(
-                target_os = "ios",
-                target_os = "visionos",
-                target_os = "macos",
-                target_os = "tvos",
-                target_os = "watchos",
-            )
-        )
-    ))]
     #[inline]
     pub fn build(self) -> NetworkScheme {
-        if matches!(
-            (&self.proxy_scheme, &self.addresses, &self.interface),
-            (None, (None, None), None)
-        ) {
-            return NetworkScheme::Default;
-        }
-
-        NetworkScheme::Scheme {
-            interface: self.interface,
-            addresses: self.addresses,
-            proxy_scheme: self.proxy_scheme,
-        }
-    }
-
-    #[cfg(not(any(
-        target_os = "android",
-        target_os = "fuchsia",
-        target_os = "linux",
-        all(
-            feature = "apple-bindable-device",
-            any(
-                target_os = "ios",
-                target_os = "visionos",
-                target_os = "macos",
-                target_os = "tvos",
-                target_os = "watchos",
+        #[cfg(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
             )
-        )
-    )))]
-    #[inline]
-    pub fn build(self) -> NetworkScheme {
-        if matches!((&self.proxy_scheme, &self.addresses), (None, (None, None))) {
-            return NetworkScheme::Default;
+        ))]
+        {
+            if matches!(
+                (&self.proxy_scheme, &self.addresses, &self.interface),
+                (None, (None, None), None)
+            ) {
+                return NetworkScheme::Default;
+            }
+
+            NetworkScheme::Scheme {
+                interface: self.interface,
+                addresses: self.addresses,
+                proxy_scheme: self.proxy_scheme,
+            }
         }
 
-        NetworkScheme::Scheme {
-            addresses: self.addresses,
-            proxy_scheme: self.proxy_scheme,
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
+        )))]
+        {
+            if matches!((&self.proxy_scheme, &self.addresses), (None, (None, None))) {
+                return NetworkScheme::Default;
+            }
+
+            NetworkScheme::Scheme {
+                addresses: self.addresses,
+                proxy_scheme: self.proxy_scheme,
+            }
         }
     }
 }

--- a/src/util/client/network.rs
+++ b/src/util/client/network.rs
@@ -61,7 +61,7 @@ impl NetworkScheme {
         NetworkSchemeBuilder::default()
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn take_proxy_scheme(&mut self) -> Option<ProxyScheme> {
         match self {
             NetworkScheme::Scheme {
@@ -72,7 +72,7 @@ impl NetworkScheme {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn take_addresses(&mut self) -> (Option<Ipv4Addr>, Option<Ipv6Addr>) {
         match self {
             NetworkScheme::Scheme { addresses, .. } => (addresses.0.take(), addresses.1.take()),
@@ -95,13 +95,11 @@ impl NetworkScheme {
             )
         )
     ))]
-    #[inline]
+    #[inline(always)]
     pub fn take_interface(&mut self) -> Option<std::borrow::Cow<'static, str>> {
-        {
-            match self {
-                NetworkScheme::Scheme { interface, .. } => interface.take(),
-                _ => None,
-            }
+        match self {
+            NetworkScheme::Scheme { interface, .. } => interface.take(),
+            _ => None,
         }
     }
 }

--- a/src/util/client/network.rs
+++ b/src/util/client/network.rs
@@ -1,76 +1,58 @@
 //! Request network scheme.
-use crate::{cfg_bindable_device, cfg_non_bindable_device, proxy::ProxyScheme};
+use crate::proxy::ProxyScheme;
 use std::{
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-cfg_bindable_device! {
-    /// Represents the network configuration scheme.
-    ///
-    /// This enum defines different strategies for configuring network settings,
-    /// such as binding to specific interfaces, addresses, or proxy schemes.
-    #[derive(Clone, Hash, PartialEq, Eq, Default)]
-    pub enum NetworkScheme {
-        /// Custom network scheme with specific configurations.
-        Scheme {
-            /// Specifies the network interface to bind to using `SO_BINDTODEVICE`.
-            ///
-            /// - **Supported Platforms:** Android, Fuchsia, Linux and Apple platforms.
-            /// - **Purpose:** Allows binding network traffic to a specific network interface.
-            interface: Option<std::borrow::Cow<'static, str>>,
-
-            /// Specifies IP addresses to bind sockets before establishing a connection.
-            ///
-            /// - **Tuple Structure:** `(Option<Ipv4Addr>, Option<Ipv6Addr>)`
-            /// - **Purpose:** Ensures that all sockets use the specified IP addresses
-            ///   for both IPv4 and IPv6 connections.
-            addresses: (Option<Ipv4Addr>, Option<Ipv6Addr>),
-
-            /// Defines the proxy scheme for network requests.
-            ///
-            /// - **Examples:** HTTP, HTTPS, SOCKS5, SOCKS5h.
-            /// - **Purpose:** Routes network traffic through a specified proxy.
-            proxy_scheme: Option<ProxyScheme>,
-        },
-
-        /// The default network scheme.
+/// Represents the network configuration scheme.
+///
+/// This enum defines different strategies for configuring network settings,
+/// such as binding to specific interfaces, addresses, or proxy schemes.
+#[derive(Clone, Hash, PartialEq, Eq, Default)]
+pub enum NetworkScheme {
+    /// Custom network scheme with specific configurations.
+    Scheme {
+        /// Specifies the network interface to bind to using `SO_BINDTODEVICE`.
         ///
-        /// - **Purpose:** Represents a standard or unconfigured network state.
-        #[default]
-        Default,
-    }
-}
+        /// - **Supported Platforms:** Android, Fuchsia, Linux and Apple platforms.
+        /// - **Purpose:** Allows binding network traffic to a specific network interface.
+        #[cfg(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
+        ))]
+        interface: Option<std::borrow::Cow<'static, str>>,
 
-cfg_non_bindable_device! {
-    /// Represents the network configuration scheme.
-    ///
-    /// This enum defines different strategies for configuring network settings,
-    /// such as binding to specific interfaces, addresses, or proxy schemes.
-    #[derive(Clone, Hash, PartialEq, Eq, Default)]
-    pub enum NetworkScheme {
-        /// Custom network scheme with specific configurations.
-        Scheme {
-            /// Specifies IP addresses to bind sockets before establishing a connection.
-            ///
-            /// - **Tuple Structure:** `(Option<Ipv4Addr>, Option<Ipv6Addr>)`
-            /// - **Purpose:** Ensures that all sockets use the specified IP addresses
-            ///   for both IPv4 and IPv6 connections.
-            addresses: (Option<Ipv4Addr>, Option<Ipv6Addr>),
-
-            /// Defines the proxy scheme for network requests.
-            ///
-            /// - **Examples:** HTTP, HTTPS, SOCKS5, SOCKS5h.
-            /// - **Purpose:** Routes network traffic through a specified proxy.
-            proxy_scheme: Option<ProxyScheme>,
-        },
-
-        /// The default network scheme.
+        /// Specifies IP addresses to bind sockets before establishing a connection.
         ///
-        /// - **Purpose:** Represents a standard or unconfigured network state.
-        #[default]
-        Default,
-    }
+        /// - **Tuple Structure:** `(Option<Ipv4Addr>, Option<Ipv6Addr>)`
+        /// - **Purpose:** Ensures that all sockets use the specified IP addresses
+        ///   for both IPv4 and IPv6 connections.
+        addresses: (Option<Ipv4Addr>, Option<Ipv6Addr>),
+
+        /// Defines the proxy scheme for network requests.
+        ///
+        /// - **Examples:** HTTP, HTTPS, SOCKS5, SOCKS5h.
+        /// - **Purpose:** Routes network traffic through a specified proxy.
+        proxy_scheme: Option<ProxyScheme>,
+    },
+
+    /// The default network scheme.
+    ///
+    /// - **Purpose:** Represents a standard or unconfigured network state.
+    #[default]
+    Default,
 }
 
 /// ==== impl NetworkScheme ====
@@ -98,14 +80,27 @@ impl NetworkScheme {
         }
     }
 
-    cfg_bindable_device! {
-        #[inline]
-        pub fn take_interface(&mut self) -> Option<std::borrow::Cow<'static, str>> {
-            {
-                match self {
-                    NetworkScheme::Scheme { interface, .. } => interface.take(),
-                    _ => None,
-                }
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
+    #[inline]
+    pub fn take_interface(&mut self) -> Option<std::borrow::Cow<'static, str>> {
+        {
+            match self {
+                NetworkScheme::Scheme { interface, .. } => interface.take(),
+                _ => None,
             }
         }
     }
@@ -113,93 +108,123 @@ impl NetworkScheme {
 
 impl fmt::Debug for NetworkScheme {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        cfg_bindable_device! {
-            match self {
-                NetworkScheme::Scheme {
-                    interface,
-                    addresses,
-                    proxy_scheme,
-                } => {
-                    write!(f, "{{")?;
+        #[cfg(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
+        ))]
+        match self {
+            NetworkScheme::Scheme {
+                interface,
+                addresses,
+                proxy_scheme,
+            } => {
+                write!(f, "{{")?;
 
-                    // Only print the interface value if it is Some and not None
-                    if let Some(interface) = interface {
-                        write!(f, " interface={:?},", interface)?;
-                    }
-
-                    // Only print the IPv4 address value if it is Some and not None
-                    if let Some(v4) = &addresses.0 {
-                        write!(f, " ipv4={:?},", v4)?;
-                    }
-
-                    // Only print the IPv6 address value if it is Some and not None
-                    if let Some(v6) = &addresses.1 {
-                        write!(f, " ipv6={:?}),", v6)?;
-                    }
-
-                    // Only print the proxy_scheme value if it is Some and not None
-                    if let Some(proxy) = proxy_scheme {
-                        write!(f, " proxy={:?},", proxy)?;
-                    }
-
-                    write!(f, "}}")
+                // Only print the interface value if it is Some and not None
+                if let Some(interface) = interface {
+                    write!(f, " interface={:?},", interface)?;
                 }
-                NetworkScheme::Default => {
-                    write!(f, "default")
+
+                // Only print the IPv4 address value if it is Some and not None
+                if let Some(v4) = &addresses.0 {
+                    write!(f, " ipv4={:?},", v4)?;
                 }
+
+                // Only print the IPv6 address value if it is Some and not None
+                if let Some(v6) = &addresses.1 {
+                    write!(f, " ipv6={:?}),", v6)?;
+                }
+
+                // Only print the proxy_scheme value if it is Some and not None
+                if let Some(proxy) = proxy_scheme {
+                    write!(f, " proxy={:?},", proxy)?;
+                }
+
+                write!(f, "}}")
+            }
+            NetworkScheme::Default => {
+                write!(f, "default")
             }
         }
 
-        cfg_non_bindable_device! {
-            match self {
-                NetworkScheme::Scheme {
-                    addresses,
-                    proxy_scheme,
-                } => {
-                    write!(f, "{{ ")?;
+        #[cfg(not(any(
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "linux",
+            all(
+                feature = "apple-bindable-device",
+                any(
+                    target_os = "ios",
+                    target_os = "visionos",
+                    target_os = "macos",
+                    target_os = "tvos",
+                    target_os = "watchos",
+                )
+            )
+        )))]
+        match self {
+            NetworkScheme::Scheme {
+                addresses,
+                proxy_scheme,
+            } => {
+                write!(f, "{{ ")?;
 
-                    // Only print the IPv4 address value if it is Some and not None
-                    if let Some(v4) = &addresses.0 {
-                        write!(f, " ipv4={:?},", v4)?;
-                    }
-
-                    // Only print the IPv6 address value if it is Some and not None
-                    if let Some(v6) = &addresses.1 {
-                        write!(f, " ipv6={:?}),", v6)?;
-                    }
-
-                    // Only print the proxy_scheme value if it is Some and not None
-                    if let Some(proxy) = proxy_scheme {
-                        write!(f, " proxy={:?},", proxy)?;
-                    }
-
-                    write!(f, "}}")
+                // Only print the IPv4 address value if it is Some and not None
+                if let Some(v4) = &addresses.0 {
+                    write!(f, " ipv4={:?},", v4)?;
                 }
-                NetworkScheme::Default => {
-                    write!(f, "default")
+
+                // Only print the IPv6 address value if it is Some and not None
+                if let Some(v6) = &addresses.1 {
+                    write!(f, " ipv6={:?}),", v6)?;
                 }
+
+                // Only print the proxy_scheme value if it is Some and not None
+                if let Some(proxy) = proxy_scheme {
+                    write!(f, " proxy={:?},", proxy)?;
+                }
+
+                write!(f, "}}")
+            }
+            NetworkScheme::Default => {
+                write!(f, "default")
             }
         }
     }
 }
 
-cfg_bindable_device! {
-    /// Builder for `NetworkScheme`.
-    #[derive(Clone, Debug, Default)]
-    pub struct NetworkSchemeBuilder {
-        interface: Option<std::borrow::Cow<'static, str>>,
-        addresses: (Option<Ipv4Addr>, Option<Ipv6Addr>),
-        proxy_scheme: Option<ProxyScheme>,
-    }
-}
-
-cfg_non_bindable_device! {
-    /// Builder for `NetworkScheme`.
-    #[derive(Clone, Debug, Default)]
-    pub struct NetworkSchemeBuilder {
-        addresses: (Option<Ipv4Addr>, Option<Ipv6Addr>),
-        proxy_scheme: Option<ProxyScheme>,
-    }
+/// Builder for `NetworkScheme`.
+#[derive(Clone, Debug, Default)]
+pub struct NetworkSchemeBuilder {
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
+    interface: Option<std::borrow::Cow<'static, str>>,
+    addresses: (Option<Ipv4Addr>, Option<Ipv6Addr>),
+    proxy_scheme: Option<ProxyScheme>,
 }
 
 /// ==== impl NetworkSchemeBuilder ====
@@ -224,15 +249,28 @@ impl NetworkSchemeBuilder {
         self
     }
 
-    cfg_bindable_device! {
-        #[inline]
-        pub fn interface<I>(&mut self, interface: I) -> &mut Self
-        where
-            I: Into<std::borrow::Cow<'static, str>>,
-        {
-            self.interface = Some(interface.into());
-            self
-        }
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
+    #[inline]
+    pub fn interface<I>(&mut self, interface: I) -> &mut Self
+    where
+        I: Into<std::borrow::Cow<'static, str>>,
+    {
+        self.interface = Some(interface.into());
+        self
     }
 
     #[inline]
@@ -241,32 +279,61 @@ impl NetworkSchemeBuilder {
         self
     }
 
-    cfg_bindable_device! {
-        #[inline]
-        pub fn build(self) -> NetworkScheme {
-            if matches!((&self.proxy_scheme, &self.addresses, &self.interface), (None, (None, None), None)) {
-                return NetworkScheme::Default;
-            }
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
+    #[inline]
+    pub fn build(self) -> NetworkScheme {
+        if matches!(
+            (&self.proxy_scheme, &self.addresses, &self.interface),
+            (None, (None, None), None)
+        ) {
+            return NetworkScheme::Default;
+        }
 
-            NetworkScheme::Scheme {
-                interface: self.interface,
-                addresses: self.addresses,
-                proxy_scheme: self.proxy_scheme,
-            }
+        NetworkScheme::Scheme {
+            interface: self.interface,
+            addresses: self.addresses,
+            proxy_scheme: self.proxy_scheme,
         }
     }
 
-    cfg_non_bindable_device! {
-        #[inline]
-        pub fn build(self) -> NetworkScheme {
-            if matches!((&self.proxy_scheme, &self.addresses), (None, (None, None))) {
-                return NetworkScheme::Default;
-            }
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    )))]
+    #[inline]
+    pub fn build(self) -> NetworkScheme {
+        if matches!((&self.proxy_scheme, &self.addresses), (None, (None, None))) {
+            return NetworkScheme::Default;
+        }
 
-            NetworkScheme::Scheme {
-                addresses: self.addresses,
-                proxy_scheme: self.proxy_scheme,
-            }
+        NetworkScheme::Scheme {
+            addresses: self.addresses,
+            proxy_scheme: self.proxy_scheme,
         }
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to how the code handles conditional compilation for bindable devices. The primary focus is on replacing the `cfg_bindable_device` and `cfg_non_bindable_device` macros with direct `#[cfg]` attributes. Additionally, there are some minor formatting adjustments in the `Cargo.toml` file.

### Conditional Compilation Changes:
* Removed `cfg_bindable_device` and `cfg_non_bindable_device` macros and replaced them with direct `#[cfg]` attributes in various files. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L31-R31) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L856) [[3]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90R866-L874) [[4]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1787-R1816) [[5]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1797) [[6]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56L19-R19) [[7]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56L582-R598) [[8]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56L593) [[9]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L281-L330) [[10]](diffhunk://#diff-83bb6cf4e4ce2ec69ffa0070af651d1ce24bb424f8ed3a13abc2c052dc021cadL9) [[11]](diffhunk://#diff-83bb6cf4e4ce2ec69ffa0070af651d1ce24bb424f8ed3a13abc2c052dc021cadL68-L70) [[12]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L22) [[13]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L403-R416) [[14]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L412) [[15]](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL37-R37) [[16]](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL203-R237) [[17]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L2-L8) [[18]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581R20-R34) [[19]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L43-L74) [[20]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L101-R97) [[21]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L112-R125) [[22]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L151-R175) [[23]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L184-L203) [[24]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L227-R266)

### Formatting Adjustments:
* Reformatted dependency lines in `Cargo.toml` for better readability. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L135-R136) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L178-R174)