### PR TITLE
chore(websocket): Simplify error handling and improve code readability

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -302,6 +302,10 @@ pub(crate) fn redirect<E: Into<BoxError>>(e: E, url: Url) -> Error {
     Error::new(Kind::Redirect, Some(e)).with_url(url)
 }
 
+pub(crate) fn upgrade<E: Into<BoxError>>(e: E) -> Error {
+    Error::new(Kind::Upgrade, Some(e))
+}
+
 pub(crate) fn status_code(url: Url, status: StatusCode) -> Error {
     Error::new(Kind::Status(status), None::<Error>).with_url(url)
 }
@@ -316,10 +320,6 @@ pub(crate) fn url_bad_uri(url: Url) -> Error {
 
 pub(crate) fn uri_bad_host() -> Error {
     Error::new(Kind::Builder, Some("no host in url"))
-}
-
-pub(crate) fn upgrade<E: Into<BoxError>>(e: E) -> Error {
-    Error::new(Kind::Upgrade, Some(e))
 }
 
 // io::Error helpers


### PR DESCRIPTION
This pull request includes several changes to the `src/client/websocket/mod.rs` and `src/error.rs` files to simplify error handling and improve code readability. The most important changes include consolidating error imports, refactoring error creation, and modifying error handling in the `WebSocketResponse` and `WebSocket` implementations.

Improvements to error handling and code readability:

* [`src/client/websocket/mod.rs`](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL14-R22): Consolidated imports from `crate::error` and moved `pub use message::{CloseCode, CloseFrame, Message, Utf8Bytes};` to the top of the file.
* [`src/client/websocket/mod.rs`](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL222-R222): Refactored error creation in `WebSocketRequestBuilder` to use the new `error::upgrade` function.
* [`src/client/websocket/mod.rs`](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL297-R312): Modified `WebSocketResponse` to use `error::upgrade` for various error conditions, improving consistency and readability. [[1]](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL297-R312) [[2]](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL329-R346) [[3]](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL368-R378)
* [`src/client/websocket/mod.rs`](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL490-R475): Updated `Stream` implementation for `WebSocket` to use `error::body` for error handling.
* [`src/error.rs`](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eR305-R308): Added a new `upgrade` function for creating upgrade errors and removed the redundant `upgrade` function definition. [[1]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eR305-R308) [[2]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL321-L324)