### PR TITLE
Revert "deps(tokio): Remove unused `rt` feature" 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,11 @@ lru = { version = "0.13", default-features = false }
 log = "0.4"
 mime = "0.3.17"
 percent-encoding = "2.3"
-tokio = { version = "1", default-features = false, features = ["net","time"] }
+tokio = { version = "1", default-features = false, features = [
+    "net",
+    "time",
+    "rt",
+] }
 pin-project-lite = "0.2.0"
 ipnet = "2.11.0"
 arc-swap = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,11 +106,7 @@ lru = { version = "0.13", default-features = false }
 log = "0.4"
 mime = "0.3.17"
 percent-encoding = "2.3"
-tokio = { version = "1", default-features = false, features = [
-    "net",
-    "time",
-    "rt",
-] }
+tokio = { version = "1", default-features = false, features = ["net","time","rt"] }
 pin-project-lite = "0.2.0"
 ipnet = "2.11.0"
 arc-swap = "1.7.0"


### PR DESCRIPTION
This pull request includes a small but important change to the `Cargo.toml` file to ensure compatibility with additional runtime features.

Dependency update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L109-R109): Updated the `tokio` dependency to include the `rt` feature in addition to `net` and `time` to enable runtime features.