### PR TITLE
perf(socks): Use non-blocking DNS query in Socks connection process

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -319,7 +319,7 @@ impl ConnectorService {
         mut dst: Dst,
         proxy_scheme: ProxyScheme,
     ) -> Result<Conn, BoxError> {
-        log::debug!("proxy({:?}) intercepts '{:?}'", proxy_scheme, dst);
+        log::debug!("proxy({:?}) intercepts '{:?}'", proxy_scheme, dst.uri());
 
         let (proxy_dst, auth) = match proxy_scheme {
             ProxyScheme::Http { host, auth } => (into_uri(Scheme::HTTP, host)?, auth),
@@ -732,7 +732,6 @@ mod tunnel {
 #[cfg(feature = "socks")]
 mod socks {
     use std::io;
-    use std::net::ToSocketAddrs;
 
     use http::Uri;
     use tokio::net::TcpStream;
@@ -763,7 +762,7 @@ mod socks {
         };
 
         if let DnsResolve::Local = dns {
-            let maybe_new_target = (host.as_str(), port).to_socket_addrs()?.next();
+            let maybe_new_target = tokio::net::lookup_host((host.as_str(), port)).await?.next();
             if let Some(new_target) = maybe_new_target {
                 host = new_target.ip().to_string();
             }


### PR DESCRIPTION
This pull request includes several changes to the `src/connect.rs` file aimed at improving logging and DNS resolution. The most important changes are:

Logging improvement:
* [`src/connect.rs`](diffhunk://#diff-4e7bfdc1a4370e34beb83e080ba29965735d732b714e5dde381bee13daec97b9L322-R322): Modified the logging statement in the `ConnectorService` implementation to log the URI of the destination instead of the destination itself.

DNS resolution improvement:
* [`src/connect.rs`](diffhunk://#diff-4e7bfdc1a4370e34beb83e080ba29965735d732b714e5dde381bee13daec97b9L766-R765): Replaced the use of the `ToSocketAddrs` trait with `tokio::net::lookup_host` for asynchronous DNS resolution in the `socks` module.

Code cleanup:
* [`src/connect.rs`](diffhunk://#diff-4e7bfdc1a4370e34beb83e080ba29965735d732b714e5dde381bee13daec97b9L735): Removed the unused import of the `ToSocketAddrs` trait in the `socks` module.