### PR TITLE
refactor(tls): Refactor TLS connector structure

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -241,11 +241,7 @@ impl ConnectorService {
         };
 
         if dst.scheme() == Some(&Scheme::HTTPS) {
-            let http = HttpsConnector::builder(self.http.clone())
-                .alpn_protos(dst.alpn_protos())
-                .interface(dst.take_interface())
-                .addresses(dst.take_addresses())
-                .build(self.tls.clone());
+            let http = HttpsConnector::new(self.http.clone(), self.tls.clone(), &mut dst);
 
             log::trace!("socks HTTPS over proxy");
             let host = dst.host().ok_or(crate::error::uri_bad_host())?;
@@ -284,11 +280,7 @@ impl ConnectorService {
         }
 
         log::trace!("connect with maybe proxy");
-        let mut http = HttpsConnector::builder(http)
-            .alpn_protos(dst.alpn_protos())
-            .interface(dst.take_interface())
-            .addresses(dst.take_addresses())
-            .build(self.tls);
+        let mut http = HttpsConnector::new(http, self.tls, &mut dst);
         let io = http.call(dst.into()).await?;
 
         if let MaybeHttpsStream::Https(stream) = io {
@@ -331,11 +323,7 @@ impl ConnectorService {
         };
 
         if dst.scheme() == Some(&Scheme::HTTPS) {
-            let mut http = HttpsConnector::builder(self.http.clone())
-                .alpn_protos(dst.alpn_protos())
-                .interface(dst.take_interface())
-                .addresses(dst.take_addresses())
-                .build(self.tls);
+            let mut http = HttpsConnector::new(self.http.clone(), self.tls, &mut dst);
 
             let host = dst.host().ok_or(crate::error::uri_bad_host())?;
             let port = dst.port_u16().unwrap_or(443);

--- a/src/tls/conn/boring.rs
+++ b/src/tls/conn/boring.rs
@@ -1,30 +1,33 @@
 /// referrer: https://github.com/cloudflare/boring/blob/master/hyper-boring/src/lib.rs
 use super::cache::{SessionCache, SessionKey};
-use super::{key_index, HttpsConnectorBuilder, HttpsLayerSettings, MaybeHttpsStream};
+use super::{key_index, HttpsConnectorBuilder, MaybeHttpsStream, TlsSettings};
+
 use crate::connect::HttpConnector;
 use crate::error::BoxError;
-
-use crate::tls::ConnectConfigurationExt;
+use crate::tls::{ConnectConfigurationExt, SslConnectorBuilderExt, TlsConfig, TlsResult};
 use crate::util::client::connect::Connection;
 use crate::util::rt::TokioIo;
+
 use antidote::Mutex;
 use boring2::error::ErrorStack;
 use boring2::ssl::{
-    ConnectConfiguration, Ssl, SslConnector, SslConnectorBuilder, SslRef, SslSessionCacheMode,
+    ConnectConfiguration, Ssl, SslConnector, SslConnectorBuilder, SslMethod, SslOptions, SslRef,
+    SslSessionCacheMode,
 };
 use http::uri::Scheme;
 use http::Uri;
 use hyper2::rt::{Read, Write};
+
+use tokio_boring2::SslStream;
+use tower_service::Service;
+
 use std::error::Error;
 use std::fmt::Debug;
 use std::future::Future;
 use std::net::Ipv6Addr;
-use tokio_boring2::SslStream;
-
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tower_service::Service;
 
 /// A Connector using BoringSSL to support `http` and `https` schemes.
 #[derive(Clone)]
@@ -48,10 +51,10 @@ where
     T: Read + Write + Connection + Unpin + Debug + Sync + Send + 'static,
 {
     /// Creates a new `HttpsConnector` with a given `HttpConnector`
-    pub fn with_connector_layer(http: S, layer: HttpsLayer) -> HttpsConnector<S> {
+    pub fn with_connector(http: S, connector: BoringTlsConnector) -> HttpsConnector<S> {
         HttpsConnector {
             http,
-            inner: layer.inner,
+            inner: connector.inner,
         }
     }
 
@@ -85,7 +88,7 @@ where
 
 /// A layer which wraps services in an `HttpsConnector`.
 #[derive(Clone)]
-pub struct HttpsLayer {
+pub struct BoringTlsConnector {
     inner: Inner,
 }
 
@@ -102,12 +105,100 @@ type Callback =
     Arc<dyn Fn(&mut ConnectConfiguration, &Uri) -> Result<(), ErrorStack> + Sync + Send>;
 type SslCallback = Arc<dyn Fn(&mut SslRef, &Uri) -> Result<(), ErrorStack> + Sync + Send>;
 
-impl HttpsLayer {
-    /// Creates a new `HttpsLayer` with settings
-    pub fn with_connector_and_settings(
+impl BoringTlsConnector {
+    /// Creates a new `BoringTlsConnector` with the given `TlsConfig`.
+    pub fn new(config: TlsConfig) -> TlsResult<BoringTlsConnector> {
+        let mut connector = SslConnector::no_default_verify_builder(SslMethod::tls_client())?
+            .root_cert_store(config.root_certs_store)?
+            .cert_verification(config.certs_verification)?
+            .alpn_protos(config.alpn_protos)?
+            .min_tls_version(config.min_tls_version)?
+            .max_tls_version(config.max_tls_version)?;
+
+        if config.enable_ocsp_stapling {
+            connector.enable_ocsp_stapling();
+        }
+
+        if config.enable_signed_cert_timestamps {
+            connector.enable_signed_cert_timestamps();
+        }
+
+        if !config.session_ticket {
+            connector.set_options(SslOptions::NO_TICKET);
+        }
+
+        if !config.psk_dhe_ke {
+            connector.set_options(SslOptions::NO_PSK_DHE_KE);
+        }
+
+        if !config.renegotiation {
+            connector.set_options(SslOptions::NO_RENEGOTIATION);
+        }
+
+        if let Some(grease_enabled) = config.grease_enabled {
+            connector.set_grease_enabled(grease_enabled);
+        }
+
+        if let Some(permute_extensions) = config.permute_extensions {
+            connector.set_permute_extensions(permute_extensions);
+        }
+
+        if let Some(curves) = config.curves.as_deref() {
+            connector.set_curves(curves)?;
+        }
+
+        if let Some(sigalgs_list) = config.sigalgs_list.as_deref() {
+            connector.set_sigalgs_list(sigalgs_list)?;
+        }
+
+        if let Some(delegated_credentials) = config.delegated_credentials.as_deref() {
+            connector.set_delegated_credentials(delegated_credentials)?;
+        }
+
+        if let Some(cipher_list) = config.cipher_list.as_deref() {
+            connector.set_cipher_list(cipher_list)?;
+        }
+
+        if let Some(cert_compression_algorithm) = config.cert_compression_algorithm {
+            for algorithm in cert_compression_algorithm.iter() {
+                connector = connector.add_cert_compression_algorithm(*algorithm)?;
+            }
+        }
+
+        if let Some(record_size_limit) = config.record_size_limit {
+            connector.set_record_size_limit(record_size_limit);
+        }
+
+        if let Some(limit) = config.key_shares_limit {
+            connector.set_key_shares_limit(limit);
+        }
+
+        if let Some(indices) = config.extension_permutation_indices {
+            connector.set_extension_permutation_indices(indices.as_ref())?;
+        }
+
+        // Create the `TlsSettings` with the default session cache capacity.
+        let settings = TlsSettings::builder()
+            .session_cache(config.pre_shared_key)
+            .skip_session_ticket(config.psk_skip_session_ticket)
+            .alpn_protos(config.alpn_protos)
+            .alps_protos(config.alps_protos)
+            .alps_use_new_codepoint(config.alps_use_new_codepoint)
+            .enable_ech_grease(config.enable_ech_grease)
+            .tls_sni(config.tls_sni)
+            .verify_hostname(config.verify_hostname)
+            .build();
+
+        Ok(BoringTlsConnector::with_connector_and_settings(
+            connector, settings,
+        ))
+    }
+
+    /// Creates a new `BoringTlsConnector` with settings
+    fn with_connector_and_settings(
         mut ssl: SslConnectorBuilder,
-        settings: HttpsLayerSettings,
-    ) -> HttpsLayer {
+        settings: TlsSettings,
+    ) -> BoringTlsConnector {
         // If the session cache is disabled, we don't need to set up any callbacks.
         let cache = if settings.session_cache {
             let cache = Arc::new(Mutex::new(SessionCache::with_capacity(
@@ -146,7 +237,7 @@ impl HttpsLayer {
             Ok(())
         });
 
-        HttpsLayer {
+        BoringTlsConnector {
             inner: Inner {
                 ssl: ssl.build(),
                 cache,

--- a/src/tls/conn/mod.rs
+++ b/src/tls/conn/mod.rs
@@ -46,7 +46,6 @@ pub struct HandshakeSettings {
     enable_ech_grease: bool,
 
     /// Sets whether to enable hostname verification. Defaults to `true`.
-
     #[builder(default = true)]
     verify_hostname: bool,
 

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -10,115 +10,16 @@ mod conf;
 mod conn;
 mod ext;
 
-use boring2::{
-    error::ErrorStack,
-    ssl::{SslConnector, SslMethod, SslOptions, SslVersion},
-};
-use conn::{HttpsLayer, HttpsLayerSettings};
+use boring2::{error::ErrorStack, ssl::SslVersion};
 
-pub use self::conn::{HttpsConnector, MaybeHttpsStream};
-pub use self::ext::{ConnectConfigurationExt, SslConnectorBuilderExt, SslRefExt};
+pub use self::conn::{BoringTlsConnector, HttpsConnector, MaybeHttpsStream};
+pub use self::ext::{ConnectConfigurationExt, SslConnectorBuilderExt};
 pub use self::{
     cert::{RootCertStore, RootCertStoreProvider},
     conf::TlsConfig,
 };
 
 type TlsResult<T> = Result<T, ErrorStack>;
-
-/// A wrapper around a `HttpsLayer` that allows for additional config.
-#[derive(Clone)]
-pub(crate) struct BoringTlsConnector(HttpsLayer);
-
-impl BoringTlsConnector {
-    /// Create a new `BoringTlsConnector` with the given function.
-    #[inline]
-    pub fn new(config: TlsConfig) -> TlsResult<BoringTlsConnector> {
-        let mut connector = SslConnector::no_default_verify_builder(SslMethod::tls_client())?
-            .root_cert_store(config.root_certs_store)?
-            .cert_verification(config.certs_verification)?
-            .alpn_protos(config.alpn_protos)?
-            .min_tls_version(config.min_tls_version)?
-            .max_tls_version(config.max_tls_version)?;
-
-        if config.enable_ocsp_stapling {
-            connector.enable_ocsp_stapling();
-        }
-
-        if config.enable_signed_cert_timestamps {
-            connector.enable_signed_cert_timestamps();
-        }
-
-        if !config.session_ticket {
-            connector.set_options(SslOptions::NO_TICKET);
-        }
-
-        if !config.psk_dhe_ke {
-            connector.set_options(SslOptions::NO_PSK_DHE_KE);
-        }
-
-        if !config.renegotiation {
-            connector.set_options(SslOptions::NO_RENEGOTIATION);
-        }
-
-        if let Some(grease_enabled) = config.grease_enabled {
-            connector.set_grease_enabled(grease_enabled);
-        }
-
-        if let Some(permute_extensions) = config.permute_extensions {
-            connector.set_permute_extensions(permute_extensions);
-        }
-
-        if let Some(curves) = config.curves.as_deref() {
-            connector.set_curves(curves)?;
-        }
-
-        if let Some(sigalgs_list) = config.sigalgs_list.as_deref() {
-            connector.set_sigalgs_list(sigalgs_list)?;
-        }
-
-        if let Some(delegated_credentials) = config.delegated_credentials.as_deref() {
-            connector.set_delegated_credentials(delegated_credentials)?;
-        }
-
-        if let Some(cipher_list) = config.cipher_list.as_deref() {
-            connector.set_cipher_list(cipher_list)?;
-        }
-
-        if let Some(cert_compression_algorithm) = config.cert_compression_algorithm {
-            for algorithm in cert_compression_algorithm.iter() {
-                connector = connector.add_cert_compression_algorithm(*algorithm)?;
-            }
-        }
-
-        if let Some(record_size_limit) = config.record_size_limit {
-            connector.set_record_size_limit(record_size_limit);
-        }
-
-        if let Some(limit) = config.key_shares_limit {
-            connector.set_key_shares_limit(limit);
-        }
-
-        if let Some(indices) = config.extension_permutation_indices {
-            connector.set_extension_permutation_indices(indices.as_ref())?;
-        }
-
-        // Create the `HttpsLayerSettings` with the default session cache capacity.
-        let settings = HttpsLayerSettings::builder()
-            .session_cache(config.pre_shared_key)
-            .skip_session_ticket(config.psk_skip_session_ticket)
-            .alpn_protos(config.alpn_protos)
-            .alps_protos(config.alps_protos)
-            .alps_use_new_codepoint(config.alps_use_new_codepoint)
-            .enable_ech_grease(config.enable_ech_grease)
-            .tls_sni(config.tls_sni)
-            .verify_hostname(config.verify_hostname)
-            .build();
-
-        Ok(Self(HttpsLayer::with_connector_and_settings(
-            connector, settings,
-        )))
-    }
-}
 
 /// A TLS protocol version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -198,43 +198,24 @@ impl Dst {
         Arc::make_mut(&mut self.inner).network.take_addresses()
     }
 
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        all(
+            feature = "apple-bindable-device",
+            any(
+                target_os = "ios",
+                target_os = "visionos",
+                target_os = "macos",
+                target_os = "tvos",
+                target_os = "watchos",
+            )
+        )
+    ))]
     #[inline(always)]
     pub(crate) fn take_interface(&mut self) -> Option<std::borrow::Cow<'static, str>> {
-        #[cfg(any(
-            target_os = "android",
-            target_os = "fuchsia",
-            target_os = "linux",
-            all(
-                feature = "apple-bindable-device",
-                any(
-                    target_os = "ios",
-                    target_os = "visionos",
-                    target_os = "macos",
-                    target_os = "tvos",
-                    target_os = "watchos",
-                )
-            )
-        ))]
-        {
-            Arc::make_mut(&mut self.inner).network.take_interface()
-        }
-
-        #[cfg(not(any(
-            target_os = "android",
-            target_os = "fuchsia",
-            target_os = "linux",
-            all(
-                feature = "apple-bindable-device",
-                any(
-                    target_os = "ios",
-                    target_os = "visionos",
-                    target_os = "macos",
-                    target_os = "tvos",
-                    target_os = "watchos",
-                )
-            )
-        )))]
-        None
+        Arc::make_mut(&mut self.inner).network.take_interface()
     }
 
     #[inline(always)]


### PR DESCRIPTION
This pull request includes significant changes to the `HttpsConnector` and related TLS components to simplify and enhance the codebase. The most important changes include the introduction of the `BoringTlsConnector`, the renaming and restructuring of files, and the modification of methods to use the new connector. These changes improve the maintainability and functionality of the TLS connection setup.

### Introduction of `BoringTlsConnector`:
* [`src/tls/conn/boring.rs`](diffhunk://#diff-d98b0d1de580025b82e10754916d11d3d7b8817ca234aa0768743acd80cb7536L3-L27): Introduced `BoringTlsConnector` to replace `HttpsLayer` and added methods to configure TLS settings. [[1]](diffhunk://#diff-d98b0d1de580025b82e10754916d11d3d7b8817ca234aa0768743acd80cb7536L3-L27) [[2]](diffhunk://#diff-d98b0d1de580025b82e10754916d11d3d7b8817ca234aa0768743acd80cb7536L88-R127) [[3]](diffhunk://#diff-d98b0d1de580025b82e10754916d11d3d7b8817ca234aa0768743acd80cb7536L105-R236) [[4]](diffhunk://#diff-d98b0d1de580025b82e10754916d11d3d7b8817ca234aa0768743acd80cb7536L149-R275)

### File Renaming and Restructuring:
* Renamed `src/tls/conn/layer.rs` to `src/tls/conn/boring.rs` and updated imports accordingly. [[1]](diffhunk://#diff-d98b0d1de580025b82e10754916d11d3d7b8817ca234aa0768743acd80cb7536L3-L27) [[2]](diffhunk://#diff-83bb6cf4e4ce2ec69ffa0070af651d1ce24bb424f8ed3a13abc2c052dc021cadL2-R63) [[3]](diffhunk://#diff-2fe8ca04c205b0602c61e6dba683c0cc68c15f1ddb0009207d5ae78045831a4cL13-L122)

### Method Modifications:
* [`src/connect.rs`](diffhunk://#diff-4e7bfdc1a4370e34beb83e080ba29965735d732b714e5dde381bee13daec97b9L244-R244): Updated methods in `ConnectorService` to use `HttpsConnector::new` instead of the builder pattern. [[1]](diffhunk://#diff-4e7bfdc1a4370e34beb83e080ba29965735d732b714e5dde381bee13daec97b9L244-R244) [[2]](diffhunk://#diff-4e7bfdc1a4370e34beb83e080ba29965735d732b714e5dde381bee13daec97b9L287-R283) [[3]](diffhunk://#diff-4e7bfdc1a4370e34beb83e080ba29965735d732b714e5dde381bee13daec97b9L334-R326)

### Updates to `Dst` Struct:
* [`src/util/client/mod.rs`](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL201-L202): Modified the `take_interface` method to be always available for supported platforms. [[1]](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL201-L202) [[2]](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL218-L239)

### Removal of Deprecated Code:
* [`src/tls/conn/mod.rs`](diffhunk://#diff-83bb6cf4e4ce2ec69ffa0070af651d1ce24bb424f8ed3a13abc2c052dc021cadL2-R63): Removed the old `HttpsLayer` and related builder methods, replacing them with the new `BoringTlsConnector`. [[1]](diffhunk://#diff-83bb6cf4e4ce2ec69ffa0070af651d1ce24bb424f8ed3a13abc2c052dc021cadL2-R63) [[2]](diffhunk://#diff-2fe8ca04c205b0602c61e6dba683c0cc68c15f1ddb0009207d5ae78045831a4cL13-L122)