### PR TITLE
chore: Improve Debug implementation

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1549,7 +1549,7 @@ impl Proxies {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct ClientInner {
     accepts: Accepts,
     #[cfg(feature = "cookies")]
@@ -1613,6 +1613,22 @@ impl ClientInner {
         default
     }
 }
+
+impl_debug!(ClientInner,{
+    accepts,
+    headers,
+    headers_order,
+    hyper,
+    redirect,
+    redirect_with_proxy_auth,
+    referer,
+    request_timeout,
+    read_timeout,
+    https_only,
+    http2_max_retry_count,
+    proxies,
+    network_scheme
+});
 
 /// A reference to a `ClientInner` instance.
 ///

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -129,19 +129,29 @@ struct Config {
 impl_debug!(
     Config,
     {
-        accepts,
         headers,
         headers_order,
-        proxies,
-        redirect_policy,
         accepts,
+        connect_timeout,
+        connection_verbose,
+        pool_idle_timeout,
+        pool_max_idle_per_host,
+        pool_max_size,
+        tcp_keepalive,
+        proxies,
+        auto_sys_proxy,
+        redirect_policy,
+        redirect_with_proxy_auth,
         referer,
         timeout,
-        connect_timeout,
-        https_only,
-        nodelay,
+        read_timeout,
         network_scheme,
+        nodelay,
+        hickory_dns,
         dns_overrides,
+        https_only,
+        http2_max_retry_count,
+        tls_info,
         builder,
         tls_config
     }
@@ -1539,7 +1549,7 @@ impl Proxies {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct ClientInner {
     accepts: Accepts,
     #[cfg(feature = "cookies")]
@@ -1603,22 +1613,6 @@ impl ClientInner {
         default
     }
 }
-
-impl_debug!(ClientInner,{
-    accepts,
-    headers,
-    headers_order,
-    hyper,
-    redirect,
-    redirect_with_proxy_auth,
-    referer,
-    request_timeout,
-    read_timeout,
-    https_only,
-    http2_max_retry_count,
-    proxies,
-    network_scheme
-});
 
 /// A reference to a `ClientInner` instance.
 ///

--- a/src/tls/cert/store.rs
+++ b/src/tls/cert/store.rs
@@ -255,6 +255,16 @@ impl RootCertStoreProvider {
     }
 }
 
+impl std::fmt::Debug for RootCertStoreProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RootCertStoreProvider::Owned(_) => f.debug_tuple("Owned").finish(),
+            RootCertStoreProvider::Borrowed(_) => f.debug_tuple("Borrowed").finish(),
+            RootCertStoreProvider::Default => f.debug_tuple("Default").finish(),
+        }
+    }
+}
+
 macro_rules! impl_root_cert_store {
     ($($type:ty => $variant:ident),* $(,)?) => {
         $(

--- a/src/tls/conf.rs
+++ b/src/tls/conf.rs
@@ -1,5 +1,4 @@
 use super::{AlpnProtos, AlpsProtos, RootCertStoreProvider, TlsVersion};
-use crate::impl_debug;
 use boring2::ssl::{CertCompressionAlgorithm, SslCurve};
 use std::borrow::Cow;
 use typed_builder::TypedBuilder;
@@ -8,7 +7,7 @@ use typed_builder::TypedBuilder;
 ///
 /// This struct defines various parameters to fine-tune the behavior of a TLS connection,
 /// including the root certificate store, certificate verification, ALPN protocols, and more.
-#[derive(TypedBuilder)]
+#[derive(Debug, TypedBuilder)]
 pub struct TlsConfig {
     /// The root certificate store.
     /// Default use system's native certificate store.
@@ -193,36 +192,6 @@ impl Default for TlsConfig {
         Self::builder().build()
     }
 }
-
-impl_debug!(
-    TlsConfig,
-    {
-        certs_verification,
-        tls_sni,
-        verify_hostname,
-        alpn_protos,
-        session_ticket,
-        min_tls_version,
-        max_tls_version,
-        alps_protos,
-        psk_dhe_ke,
-        pre_shared_key,
-        enable_ech_grease,
-        permute_extensions,
-        grease_enabled,
-        enable_ocsp_stapling,
-        renegotiation,
-        curves,
-        sigalgs_list,
-        cipher_list,
-        enable_signed_cert_timestamps,
-        cert_compression_algorithm,
-        record_size_limit,
-        key_shares_limit,
-        psk_skip_session_ticket,
-        extension_permutation_indices
-    }
-);
 
 /// A trait for converting various types into an optional `Cow` containing a slice of `CertCompressionAlgorithm`.
 ///


### PR DESCRIPTION
This pull request includes several changes to improve the debugging capabilities and simplify the codebase in the `src/client/http.rs` and `src/tls` modules. The most important changes include adding new fields to the `Config` struct, implementing the `Debug` trait for several structs, and removing the `impl_debug` macro usage.

### Improvements to debugging capabilities:

* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1542-R1552): Added the `Debug` trait to the `ClientInner` and `Proxies` structs. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1542-R1552) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1607-L1622)
* [`src/tls/cert/store.rs`](diffhunk://#diff-865db2a8a6febb7baa5806b7175e17ee81ea21b9277f59fe6697ab4a919a0c09R258-R267): Implemented the `Debug` trait for the `RootCertStoreProvider` enum.

### Codebase simplification:

* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L132-R154): Added new fields to the `Config` struct, such as `connect_timeout`, `connection_verbose`, `pool_idle_timeout`, and others.
* [`src/tls/conf.rs`](diffhunk://#diff-90fd4b680a8985135f074def90a51a8fd515efe10a578179bf8571fdd7b08031L2): Removed the `impl_debug` macro usage for the `TlsConfig` struct and added the `Debug` trait to it. [[1]](diffhunk://#diff-90fd4b680a8985135f074def90a51a8fd515efe10a578179bf8571fdd7b08031L2) [[2]](diffhunk://#diff-90fd4b680a8985135f074def90a51a8fd515efe10a578179bf8571fdd7b08031L11-R10) [[3]](diffhunk://#diff-90fd4b680a8985135f074def90a51a8fd515efe10a578179bf8571fdd7b08031L197-L226)