### PR TITLE
build(deps): update boring requirement from 4.15.2 to 4.15.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ ipnet = "2.11.0"
 arc-swap = "1.7.0"
 
 ## boring-tls
-boring2 = { version = "4.15.2", features = ["pq-experimental", "cert-compression"] }
-tokio-boring2 = { version = "4.15.2", features = ["pq-experimental"] }
+boring2 = { version = "4.15.3", features = ["pq-experimental", "cert-compression"] }
+tokio-boring2 = { version = "4.15.3", features = ["pq-experimental"] }
 linked_hash_set = "0.1"
 
 # Optional deps...


### PR DESCRIPTION
This pull request includes a version update to the `Cargo.toml` file to ensure dependencies are up to date.

Dependency updates:

* Updated `boring2` from version `4.15.2` to `4.15.3` to include the latest features and fixes.
* Updated `tokio-boring2` from version `4.15.2` to `4.15.3` to stay consistent with `boring2` and benefit from the latest improvements.