### PR TITLE
build(feature): `apple-bindable-device` rename to `apple-network-device-binding`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ webpki-roots = ["dep:webpki-root-certs"]
 macos-system-configuration = ["dep:system-configuration"]
 
 # Use the Apple platform's network device binding.
-apple-bindable-device = ["dep:libc"]
+apple-network-device-binding = ["dep:libc"]
 
 # Optional enable http2 tracing
 http2-tracing = ["hyper2/http2-tracing"]
@@ -301,7 +301,7 @@ required-features = ["websocket", "http2-tracing", "futures-util/std"]
 [[example]]
 name = "client_chain"
 path = "examples/client_chain.rs"
-required-features = ["apple-bindable-device"]
+required-features = ["apple-network-device-binding"]
 
 [[example]]
 name = "request_with_redirect"

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -878,7 +878,7 @@ impl ClientBuilder {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",
@@ -888,7 +888,7 @@ impl ClientBuilder {
             )
         )
     ))]
-    #[cfg_attr(docsrs, feature = "apple-bindable-device")]
+    #[cfg_attr(docsrs, feature = "apple-network-device-binding")]
     pub fn interface<T>(mut self, interface: T) -> ClientBuilder
     where
         T: Into<Cow<'static, str>>,
@@ -1814,7 +1814,7 @@ impl<'c> ClientMut<'c> {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -585,7 +585,7 @@ impl RequestBuilder {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",
@@ -595,7 +595,7 @@ impl RequestBuilder {
             )
         )
     ))]
-    #[cfg_attr(docsrs, feature = "apple-bindable-device")]
+    #[cfg_attr(docsrs, feature = "apple-network-device-binding")]
     pub fn interface<I>(mut self, interface: I) -> RequestBuilder
     where
         I: Into<std::borrow::Cow<'static, str>>,

--- a/src/tls/conn/boring.rs
+++ b/src/tls/conn/boring.rs
@@ -61,7 +61,7 @@ impl HttpsConnector<HttpConnector> {
             target_os = "fuchsia",
             target_os = "linux",
             all(
-                feature = "apple-bindable-device",
+                feature = "apple-network-device-binding",
                 any(
                     target_os = "ios",
                     target_os = "visionos",

--- a/src/util/client/connect/http.rs
+++ b/src/util/client/connect/http.rs
@@ -81,7 +81,7 @@ struct Config {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",
@@ -251,7 +251,7 @@ impl<R> HttpConnector<R> {
                     target_os = "fuchsia",
                     target_os = "linux",
                     all(
-                        feature = "apple-bindable-device",
+                        feature = "apple-network-device-binding",
                         any(
                             target_os = "ios",
                             target_os = "visionos",
@@ -404,7 +404,7 @@ impl<R> HttpConnector<R> {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",
@@ -835,7 +835,7 @@ fn connect(
     }
 
     #[cfg(all(
-        feature = "apple-bindable-device",
+        feature = "apple-network-device-binding",
         any(
             target_os = "ios",
             target_os = "visionos",

--- a/src/util/client/mod.rs
+++ b/src/util/client/mod.rs
@@ -203,7 +203,7 @@ impl Dst {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",

--- a/src/util/client/network.rs
+++ b/src/util/client/network.rs
@@ -22,7 +22,7 @@ pub enum NetworkScheme {
             target_os = "fuchsia",
             target_os = "linux",
             all(
-                feature = "apple-bindable-device",
+                feature = "apple-network-device-binding",
                 any(
                     target_os = "ios",
                     target_os = "visionos",
@@ -85,7 +85,7 @@ impl NetworkScheme {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",
@@ -112,7 +112,7 @@ impl fmt::Debug for NetworkScheme {
                 target_os = "fuchsia",
                 target_os = "linux",
                 all(
-                    feature = "apple-bindable-device",
+                    feature = "apple-network-device-binding",
                     any(
                         target_os = "ios",
                         target_os = "visionos",
@@ -156,7 +156,7 @@ impl fmt::Debug for NetworkScheme {
                 target_os = "fuchsia",
                 target_os = "linux",
                 all(
-                    feature = "apple-bindable-device",
+                    feature = "apple-network-device-binding",
                     any(
                         target_os = "ios",
                         target_os = "visionos",
@@ -204,7 +204,7 @@ pub struct NetworkSchemeBuilder {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",
@@ -246,7 +246,7 @@ impl NetworkSchemeBuilder {
         target_os = "fuchsia",
         target_os = "linux",
         all(
-            feature = "apple-bindable-device",
+            feature = "apple-network-device-binding",
             any(
                 target_os = "ios",
                 target_os = "visionos",
@@ -278,7 +278,7 @@ impl NetworkSchemeBuilder {
             target_os = "fuchsia",
             target_os = "linux",
             all(
-                feature = "apple-bindable-device",
+                feature = "apple-network-device-binding",
                 any(
                     target_os = "ios",
                     target_os = "visionos",
@@ -308,7 +308,7 @@ impl NetworkSchemeBuilder {
             target_os = "fuchsia",
             target_os = "linux",
             all(
-                feature = "apple-bindable-device",
+                feature = "apple-network-device-binding",
                 any(
                     target_os = "ios",
                     target_os = "visionos",


### PR DESCRIPTION
This pull request includes changes to rename the feature flag `apple-bindable-device` to `apple-network-device-binding` across multiple files. This change ensures consistency and clarity in the codebase.

Feature flag renaming:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L70-R70): Updated `required-features` and dependencies to use `apple-network-device-binding` instead of `apple-bindable-device`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L70-R70) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L304-R304)
* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L881-R881): Renamed the feature flag in various implementations to `apple-network-device-binding`. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L881-R881) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L891-R891) [[3]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1817-R1817)
* [`src/client/request.rs`](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56L588-R588): Updated feature flag references in `RequestBuilder` implementation. [[1]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56L588-R588) [[2]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56L598-R598)
* [`src/tls/conn/boring.rs`](diffhunk://#diff-d98b0d1de580025b82e10754916d11d3d7b8817ca234aa0768743acd80cb7536L64-R64): Changed feature flag in the `HttpsConnector` implementation.
* [`src/util/client/connect/http.rs`](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L84-R84): Modified feature flag references in `Config` and `HttpConnector` implementations. [[1]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L84-R84) [[2]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L254-R254) [[3]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L407-R407) [[4]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L838-R838)
* [`src/util/client/mod.rs`](diffhunk://#diff-df53afa88f56f61a1ced749063f0cadd3e28f953e2fe205b1724790292ac945dL206-R206): Updated feature flag in `Dst` implementation.
* [`src/util/client/network.rs`](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L25-R25): Renamed feature flag in `NetworkScheme`, `NetworkSchemeBuilder`, and related implementations. [[1]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L25-R25) [[2]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L88-R88) [[3]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L115-R115) [[4]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L159-R159) [[5]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L207-R207) [[6]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L249-R249) [[7]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L281-R281) [[8]](diffhunk://#diff-2f46417cc5a88d8b84fdb4f1bbe6598c50d11f49693914a7031b86a7eb5e0581L311-R311)