### PR TITLE
build(deps): update boring requirement from 4.15.3 to 4.15.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,8 +114,8 @@ ipnet = "2.11.0"
 arc-swap = "1.7.0"
 
 ## boring-tls
-boring2 = { version = "4.15.3", features = ["pq-experimental", "cert-compression"] }
-tokio-boring2 = { version = "4.15.3", features = ["pq-experimental"] }
+boring2 = { version = "4.15.5", features = ["pq-experimental", "cert-compression"] }
+tokio-boring2 = { version = "4.15.5", features = ["pq-experimental"] }
 linked_hash_set = "0.1"
 
 # Optional deps...


### PR DESCRIPTION
This pull request includes a version bump for the `boring2` and `tokio-boring2` dependencies in the `Cargo.toml` file. The changes update these dependencies from version `4.15.3` to `4.15.5`.

Dependency updates:

* Updated `boring2` dependency from version `4.15.3` to `4.15.5` in `Cargo.toml`
* Updated `tokio-boring2` dependency from version `4.15.3` to `4.15.5` in `Cargo.toml`