### PR TITLE
build(deps): update boring requirement from 4.14.0 to 4.15.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,9 +113,9 @@ socket2 = { version = "0.5", features = ["all"] }
 lru = { version = "0.13", default-features = false }
 
 ## boring-tls
-boring2 = { version = "4.14.0", features = ["pq-experimental"] }
-boring-sys2 = { version = "4.14.0", features = ["pq-experimental"] }
-tokio-boring2 = { version = "4.14.0", features = ["pq-experimental"] }
+boring2 = { version = "4.15.6", features = ["pq-experimental"] }
+boring-sys2 = { version = "4.15.6", features = ["pq-experimental"] }
+tokio-boring2 = { version = "4.15.6", features = ["pq-experimental"] }
 foreign-types = "0.5.0"
 linked_hash_set = "0.1"
 


### PR DESCRIPTION
fix: https://github.com/0x676e67/rquest/issues/438

This may or may not be fixed, no one wants to maintain these