### PR TITLE
feat: Add chrome133 support

### DIFF
--- a/src/imp/chrome.rs
+++ b/src/imp/chrome.rs
@@ -80,6 +80,15 @@ macro_rules! tls_settings {
             .enable_ech_grease(true)
             .build()
     };
+    (7, $curves:expr) => {
+        ChromeTlsSettings::builder()
+            .curves($curves)
+            .permute_extensions(true)
+            .pre_shared_key(true)
+            .enable_ech_grease(true)
+            .alps_use_new_codepoint(true)
+            .build()
+    };
 }
 
 macro_rules! http2_settings {
@@ -255,6 +264,9 @@ mod tls {
 
         #[builder(default = false, setter(into))]
         pre_shared_key: bool,
+
+        #[builder(default = false, setter(into))]
+        alps_use_new_codepoint: bool,
     }
 
     impl From<ChromeTlsSettings> for TlsSettings {
@@ -272,6 +284,7 @@ mod tls {
                 .pre_shared_key(val.pre_shared_key)
                 .enable_ech_grease(val.enable_ech_grease)
                 .alps_protos(val.alps_protos)
+                .alps_use_new_codepoint(val.alps_use_new_codepoint)
                 .cert_compression_algorithm(CERT_COMPRESSION_ALGORITHM)
                 .build()
         }
@@ -1041,6 +1054,35 @@ mod_generator!(
         (IOS,
             r#""Microsoft Edge";v="131", "Chromium";v="131", "Not_A Brand";v="24""#,
             "Mozilla/5.0 (iPhone; CPU iPhone OS 17_7_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0"
+        )
+    ]
+);
+
+mod_generator!(
+    v133,
+    tls_settings!(7, CURVES_3),
+    http2_settings!(3),
+    header_initializer_with_zstd_priority,
+    [
+        (MacOS,
+            r#""Not(A:Brand";v="99", "Google Chrome";v="133", "Chromium";v="133""#,
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+        ),
+        (Linux,
+            r#""Not(A:Brand";v="99", "Google Chrome";v="133", "Chromium";v="133""#,
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+        ),
+        (Android,
+            r#""Not(A:Brand";v="99", "Google Chrome";v="133", "Chromium";v="133""#,
+            "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Mobile Safari/537.36"
+        ),
+        (Windows,
+            r#""Not(A:Brand";v="99", "Google Chrome";v="133", "Chromium";v="133""#,
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
+        ),
+        (IOS,
+            r#""Not(A:Brand";v="99", "Google Chrome";v="133", "Chromium";v="133""#,
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/133.0.6943.33 Mobile/15E148 Safari/604.1"
         )
     ]
 );

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -152,6 +152,7 @@ impl ImpersonateBuilder {
             Chrome129 => v129::settings,
             Chrome130 => v130::settings,
             Chrome131 => v131::settings,
+            Chrome133 => v133::settings,
 
             SafariIos17_2 => safari_ios_17_2::settings,
             SafariIos17_4_1 => safari_ios_17_4_1::settings,
@@ -238,8 +239,9 @@ pub enum Impersonate {
     Chrome128,
     Chrome129,
     Chrome130,
-    #[default]
     Chrome131,
+    #[default]
+    Chrome133,
 
     SafariIos17_2,
     SafariIos17_4_1,

--- a/src/tls/conn/layer.rs
+++ b/src/tls/conn/layer.rs
@@ -141,7 +141,7 @@ impl HttpsLayer {
             conf.set_verify_hostname(settings.verify_hostname);
 
             // Set ALPS
-            conf.alps_protos(settings.alps_protos)?;
+            conf.alps_protos(settings.alps_protos, settings.alps_use_new_codepoint)?;
 
             Ok(())
         });

--- a/src/tls/conn/mod.rs
+++ b/src/tls/conn/mod.rs
@@ -88,6 +88,7 @@ pub struct HttpsLayerSettings {
     verify_hostname: bool,
     tls_sni: bool,
     alps_protos: Option<AlpsProtos>,
+    alps_use_new_codepoint: bool,
     alpn_protos: AlpnProtos,
 }
 
@@ -108,6 +109,7 @@ impl Default for HttpsLayerSettings {
             verify_hostname: true,
             tls_sni: true,
             alps_protos: None,
+            alps_use_new_codepoint: false,
             alpn_protos: AlpnProtos::All,
         }
     }
@@ -163,6 +165,13 @@ impl HttpsLayerSettingsBuilder {
     #[inline]
     pub fn alps_protos(mut self, alps: Option<AlpsProtos>) -> Self {
         self.0.alps_protos = alps;
+        self
+    }
+
+    /// Sets whether to use the new ALPS codepoint. Defaults to `false`.
+    #[inline]
+    pub fn alps_use_new_codepoint(mut self, enable: bool) -> Self {
+        self.0.alps_use_new_codepoint = enable;
         self
     }
 

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -117,6 +117,7 @@ impl BoringTlsConnector {
             .skip_session_ticket(settings.psk_skip_session_ticket)
             .alpn_protos(settings.alpn_protos)
             .alps_protos(settings.alps_protos)
+            .alps_use_new_codepoint(settings.alps_use_new_codepoint)
             .enable_ech_grease(settings.enable_ech_grease)
             .tls_sni(settings.tls_sni)
             .verify_hostname(settings.verify_hostname)
@@ -176,16 +177,6 @@ impl AlpsProtos {
     pub const Http1: AlpsProtos = AlpsProtos(b"http/1.1");
     /// Application Settings protocol for HTTP/2
     pub const Http2: AlpsProtos = AlpsProtos(b"h2");
-
-    #[inline(always)]
-    pub(crate) fn as_ptr(&self) -> *const u8 {
-        self.0.as_ptr()
-    }
-
-    #[inline(always)]
-    pub(crate) fn len(&self) -> usize {
-        self.0.len()
-    }
 }
 
 /// Hyper extension carrying extra TLS layer information.
@@ -245,6 +236,14 @@ pub struct TlsSettings {
     /// This is specifically for applications negotiated via **ALPN**.
     #[builder(default, setter(into))]
     pub alps_protos: Option<AlpsProtos>,
+
+    /// Switching to a new codepoint for TLS ALPS extension to allow adding more data
+    /// in the ACCEPT_CH HTTP/2 and HTTP/3 frame. The ACCEPT_CH HTTP/2 frame with the
+    /// existing TLS ALPS extension had an arithmetic overflow bug in Chrome ALPS decoder.
+    /// It limits the capability to add more than 128 bytes data (in theory, the problem
+    /// range is 128 bytes to 255 bytes) to the ACCEPT_CH frame.
+    #[builder(default = false)]
+    pub alps_use_new_codepoint: bool,
 
     /// **Session Tickets** (RFC 5077) allow **session resumption** without the need for server-side state.
     ///


### PR DESCRIPTION
This pull request includes several changes to the TLS settings and introduces a new Chrome version (v133) with specific configurations. The most important changes are grouped by theme below:

### TLS Settings Enhancements:
* Added a new field `alps_use_new_codepoint` to the `ChromeTlsSettings` and `HttpsLayerSettings` structs to support the new ALPS codepoint. [[1]](diffhunk://#diff-d3a45118246025f394197b05c790e52fe4eaa04b165f71aa92220d4d6a41cfc5R267-R269) [[2]](diffhunk://#diff-83bb6cf4e4ce2ec69ffa0070af651d1ce24bb424f8ed3a13abc2c052dc021cadR91)
* Updated the `alps_protos` method in `ConnectConfigurationExt` to accept the new ALPS codepoint parameter. [[1]](diffhunk://#diff-8ea4f8c12a8a50293cee375c2af8cf7aa873af6e6dc534da267b2904b7237836L50-R54) [[2]](diffhunk://#diff-8ea4f8c12a8a50293cee375c2af8cf7aa873af6e6dc534da267b2904b7237836L121-R136)
* Modified the `HttpsLayer` and `BoringTlsConnector` implementations to use the new `alps_use_new_codepoint` field. [[1]](diffhunk://#diff-cb2cffae9d1ebf6005805896043f4fb30b451a0fc3dd32b1b2876df5c5a4eff3L144-R144) [[2]](diffhunk://#diff-2fe8ca04c205b0602c61e6dba683c0cc68c15f1ddb0009207d5ae78045831a4cR120)

### Chrome v133 Configuration:
* Introduced a new macro rule for Chrome v133 TLS settings, including enabling `permute_extensions`, `pre_shared_key`, and `alps_use_new_codepoint`.
* Added Chrome v133 to the `Impersonate` enum and `ImpersonateBuilder` settings. [[1]](diffhunk://#diff-69df82777992a617abedaef86add8fbd567bf0c4aa2369e6adb3b0be1967f6d2R155) [[2]](diffhunk://#diff-69df82777992a617abedaef86add8fbd567bf0c4aa2369e6adb3b0be1967f6d2L241-R244)
* Created a new `mod_generator` entry for Chrome v133 with specific user-agent strings for different platforms.

### Code Refactoring:
* Removed unnecessary methods from the `AlpsProtos` struct to simplify the code.

These changes enhance the flexibility and functionality of the TLS settings, especially with the introduction of the new ALPS codepoint, and add support for a new Chrome version with specific configurations.