### PR TITLE
feat: Add Android Firefox135 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 > 🚀 Help me work seamlessly with open source sharing by [sponsoring me on GitHub](https://github.com/0x676e67/0x676e67/blob/main/SPONSOR.md)
 
-An ergonomic, all-in-one HTTP client for spoofing any browser with `TLS`, `JA3`/`JA4`, and `HTTP2` fingerprints.
+An ergonomic, all-in-one HTTP client for spoofing any browser with TLS, JA3/JA4, and HTTP2 fingerprints.
+
+- <ins>This project is intended for personal learning purposes only. Use at your own risk❕</ins>
 
 ## Features
 
@@ -98,23 +100,23 @@ By default, `rquest` uses Mozilla's root certificates through the `webpki-roots`
 
   - **Chrome**
 
-    `Chrome100`，`Chrome101`，`Chrome104`，`Chrome105`，`Chrome106`，`Chrome107`，`Chrome108`，`Chrome109`，`Chrome114`，`Chrome116`，`Chrome117`，`Chrome118`，`Chrome119`，`Chrome120`，`Chrome123`，`Chrome124`，`Chrome126`，`Chrome127`，`Chrome128`，`Chrome129`，`Chrome130`，`Chrome131`
+    `Chrome100`, `Chrome101`, `Chrome104`, `Chrome105`, `Chrome106`, `Chrome107`, `Chrome108`, `Chrome109`, `Chrome114`, `Chrome116`, `Chrome117`, `Chrome118`, `Chrome119`, `Chrome120`, `Chrome123`, `Chrome124`, `Chrome126`, `Chrome127`, `Chrome128`, `Chrome129`, `Chrome130`, `Chrome131`,, `Chrome133`
 
   - **Edge**
 
-    `Edge101`，`Edge122`，`Edge127`，`Edge131`
+    `Edge101`, `Edge122`, `Edge127`, `Edge131`
 
   - **Safari**
 
-    `SafariIos17_2`，`SafariIos17_4_1`，`SafariIos16_5`，`Safari15_3`，`Safari15_5`，`Safari15_6_1`，`Safari16`，`Safari16_5`，`Safari17_0`，`Safari17_2_1`，`Safari17_4_1`，`Safari17_5`，`Safari18`，`SafariIPad18`, `Safari18_2`, `Safari18_1_1`
+    `SafariIos17_2`, `SafariIos17_4_1`, `SafariIos16_5`, `Safari15_3`, `Safari15_5`, `Safari15_6_1`, `Safari16`, `Safari16_5`, `Safari17_0`, `Safari17_2_1`, `Safari17_4_1`, `Safari17_5`, `Safari18`, `SafariIPad18`, `Safari18_2`, `Safari18_1_1`
 
   - **OkHttp**
 
-    `OkHttp3_9`，`OkHttp3_11`，`OkHttp3_13`，`OkHttp3_14`，`OkHttp4_9`，`OkHttp4_10`，`OkHttp5`
+    `OkHttp3_9`, `OkHttp3_11`, `OkHttp3_13`, `OkHttp3_14`, `OkHttp4_9`, `OkHttp4_10`, `OkHttp5`
 
   - **Firefox**
 
-    `Firefox109`, `Firefox117`, `Firefox128`, `Firefox133`
+    `Firefox109`, `Firefox117`, `Firefox128`, `Firefox133`, `Firefox135`
 
     </details>
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ By default, `rquest` uses Mozilla's root certificates through the `webpki-roots`
 
   - **Firefox**
 
-    `Firefox109`, `Firefox117`, `Firefox128`, `Firefox133`, `Firefox135`
+    `Firefox109`, `Firefox117`, `Firefox128`, `Firefox133`, `Firefox135`, `FirefoxAndroid135`
 
     </details>
 

--- a/src/imp/firefox.rs
+++ b/src/imp/firefox.rs
@@ -496,13 +496,16 @@ mod_generator!(
     http2_settings!(1),
     header_initializer_with_zstd,
     [
-        (MacOS,
+        (
+            MacOS,
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/135.0"
         ),
-        (Windows,
+        (
+            Windows,
             "Mozilla/5.0 (Windows NT 10.0; rv:133.0) Gecko/20100101 Firefox/135.0"
         ),
-        (Linux,
+        (
+            Linux,
             "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/135.0"
         )
     ]

--- a/src/imp/firefox.rs
+++ b/src/imp/firefox.rs
@@ -74,11 +74,21 @@ macro_rules! tls_settings {
             .curves($curves)
             .enable_ech_grease(true)
             .enable_signed_cert_timestamps(true)
-            .session_ticket(false)
+            .session_ticket(true)
             .pre_shared_key(true)
             .psk_skip_session_tickets(true)
             .key_shares_limit(3)
-            .psk_dhe_ke(false)
+            .cert_compression_algorithm(CERT_COMPRESSION_ALGORITHM)
+            .build()
+    };
+    (5, $cipher_list:expr, $curves:expr) => {
+        FirefoxTlsSettings::builder()
+            .cipher_list($cipher_list)
+            .curves($curves)
+            .enable_ech_grease(true)
+            .pre_shared_key(true)
+            .psk_skip_session_tickets(true)
+            .key_shares_limit(2)
             .cert_compression_algorithm(CERT_COMPRESSION_ALGORITHM)
             .build()
     };
@@ -118,6 +128,19 @@ macro_rules! http2_settings {
             .enable_push(false)
             .max_concurrent_streams(0)
             .initial_stream_window_size(131072)
+            .max_frame_size(16384)
+            .initial_connection_window_size(12517377 + 65535)
+            .headers_priority(HEADER_PRIORITY)
+            .headers_pseudo_order(HEADERS_PSEUDO_ORDER)
+            .settings_order(SETTINGS_ORDER)
+            .build()
+    };
+    (4) => {
+        Http2Settings::builder()
+            .initial_stream_id(3)
+            .header_table_size(4096)
+            .enable_push(false)
+            .initial_stream_window_size(32768)
             .max_frame_size(16384)
             .initial_connection_window_size(12517377 + 65535)
             .headers_priority(HEADER_PRIORITY)
@@ -509,4 +532,15 @@ mod_generator!(
             "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/135.0"
         )
     ]
+);
+
+mod_generator!(
+    ff_android_135,
+    tls_settings!(5, CIPHER_LIST_1, CURVES_1),
+    http2_settings!(4),
+    header_initializer_with_zstd,
+    [(
+        Android,
+        "Mozilla/5.0 (Android 13; Mobile; rv:133.0) Gecko/20100101 Firefox/135.0"
+    )]
 );

--- a/src/imp/firefox.rs
+++ b/src/imp/firefox.rs
@@ -68,6 +68,20 @@ macro_rules! tls_settings {
             .key_shares_limit(2)
             .build()
     };
+    (4, $cipher_list:expr, $curves:expr) => {
+        FirefoxTlsSettings::builder()
+            .cipher_list($cipher_list)
+            .curves($curves)
+            .enable_ech_grease(true)
+            .enable_signed_cert_timestamps(true)
+            .session_ticket(false)
+            .pre_shared_key(true)
+            .psk_skip_session_tickets(true)
+            .key_shares_limit(3)
+            .psk_dhe_ke(false)
+            .cert_compression_algorithm(CERT_COMPRESSION_ALGORITHM)
+            .build()
+    };
 }
 
 macro_rules! http2_settings {
@@ -239,6 +253,7 @@ mod tls {
             ExtensionType::APPLICATION_LAYER_PROTOCOL_NEGOTIATION,
             ExtensionType::STATUS_REQUEST,
             ExtensionType::DELEGATED_CREDENTIAL,
+            ExtensionType::CERTIFICATE_TIMESTAMP,
             ExtensionType::KEY_SHARE,
             ExtensionType::SUPPORTED_VERSIONS,
             ExtensionType::SIGNATURE_ALGORITHMS,
@@ -278,6 +293,9 @@ mod tls {
         enable_ech_grease: bool,
 
         #[builder(default = false, setter(into))]
+        enable_signed_cert_timestamps: bool,
+
+        #[builder(default = false, setter(into))]
         pre_shared_key: bool,
 
         #[builder(default = false, setter(into))]
@@ -313,6 +331,7 @@ mod tls {
                 .record_size_limit(val.record_size_limit)
                 .enable_ocsp_stapling(true)
                 .enable_ech_grease(val.enable_ech_grease)
+                .enable_signed_cert_timestamps(val.enable_signed_cert_timestamps)
                 .alpn_protos(AlpnProtos::All)
                 .min_tls_version(TlsVersion::TLS_1_2)
                 .max_tls_version(TlsVersion::TLS_1_3)
@@ -429,7 +448,7 @@ mod_generator!(
     http2_settings!(3),
     header_initializer_with_zstd,
     [
-        (MacOs,
+        (MacOS,
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Firefox/128.0"
         ),
         (Windows,
@@ -453,7 +472,7 @@ mod_generator!(
     http2_settings!(1),
     header_initializer_with_zstd,
     [
-        (MacOs,
+        (MacOS,
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0"
         ),
         (Android,
@@ -467,6 +486,24 @@ mod_generator!(
         ),
         (IOS,
             "Mozilla/5.0 (iPhone; CPU iPhone OS 18_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/133.4 Mobile/15E148 Safari/605.1.15"
+        )
+    ]
+);
+
+mod_generator!(
+    ff135,
+    tls_settings!(4, CIPHER_LIST_1, CURVES_2),
+    http2_settings!(1),
+    header_initializer_with_zstd,
+    [
+        (MacOS,
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/135.0"
+        ),
+        (Windows,
+            "Mozilla/5.0 (Windows NT 10.0; rv:133.0) Gecko/20100101 Firefox/135.0"
+        ),
+        (Linux,
+            "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/135.0"
         )
     ]
 );

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -187,7 +187,8 @@ impl ImpersonateBuilder {
             Firefox109 => ff109::settings,
             Firefox117 => ff117::settings,
             Firefox128 => ff128::settings,
-            Firefox133 => ff133::settings
+            Firefox133 => ff133::settings,
+            Firefox135 => ff135::settings
         )
     }
 }
@@ -277,6 +278,7 @@ pub enum Impersonate {
     Firefox117,
     Firefox128,
     Firefox133,
+    Firefox135,
 }
 
 /// ======== Impersonate impls ========

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -188,7 +188,8 @@ impl ImpersonateBuilder {
             Firefox117 => ff117::settings,
             Firefox128 => ff128::settings,
             Firefox133 => ff133::settings,
-            Firefox135 => ff135::settings
+            Firefox135 => ff135::settings,
+            FirefoxAndroid135 => ff_android_135::settings
         )
     }
 }
@@ -279,6 +280,7 @@ pub enum Impersonate {
     Firefox128,
     Firefox133,
     Firefox135,
+    FirefoxAndroid135,
 }
 
 /// ======== Impersonate impls ========


### PR DESCRIPTION
Firefox135 has many settings. When in privacy mode, the psk_key_exchange_modes extension will be disabled, and PSK will also be disabled.

This is only available in non-private mode emulation