### PR TITLE
refactor: reduce dependency on `futures-core` / `futures-util`

### DIFF
--- a/src/client/decoder.rs
+++ b/src/client/decoder.rs
@@ -7,7 +7,7 @@ use std::fmt;
 ))]
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 #[cfg(any(
     feature = "gzip",
@@ -336,16 +336,14 @@ impl HttpBody for Decoder {
                 Poll::Ready(Err(e)) => Poll::Ready(Some(Err(crate::error::decode_io(e)))),
                 Poll::Pending => Poll::Pending,
             },
-            Inner::PlainText(ref mut body) => {
-                match futures_util::ready!(Pin::new(body).poll_frame(cx)) {
-                    Some(Ok(frame)) => Poll::Ready(Some(Ok(frame))),
-                    Some(Err(err)) => Poll::Ready(Some(Err(crate::error::decode(err)))),
-                    None => Poll::Ready(None),
-                }
-            }
+            Inner::PlainText(ref mut body) => match ready!(Pin::new(body).poll_frame(cx)) {
+                Some(Ok(frame)) => Poll::Ready(Some(Ok(frame))),
+                Some(Err(err)) => Poll::Ready(Some(Err(crate::error::decode(err)))),
+                None => Poll::Ready(None),
+            },
             #[cfg(feature = "gzip")]
             Inner::Gzip(ref mut decoder) => {
-                match futures_util::ready!(Pin::new(&mut *decoder).poll_next(cx)) {
+                match ready!(Pin::new(&mut *decoder).poll_next(cx)) {
                     Some(Ok(bytes)) => Poll::Ready(Some(Ok(Frame::data(bytes.freeze())))),
                     Some(Err(err)) => Poll::Ready(Some(Err(crate::error::decode_io(err)))),
                     None => {
@@ -359,7 +357,7 @@ impl HttpBody for Decoder {
             }
             #[cfg(feature = "brotli")]
             Inner::Brotli(ref mut decoder) => {
-                match futures_util::ready!(Pin::new(&mut *decoder).poll_next(cx)) {
+                match ready!(Pin::new(&mut *decoder).poll_next(cx)) {
                     Some(Ok(bytes)) => Poll::Ready(Some(Ok(Frame::data(bytes.freeze())))),
                     Some(Err(err)) => Poll::Ready(Some(Err(crate::error::decode_io(err)))),
                     None => {
@@ -373,7 +371,7 @@ impl HttpBody for Decoder {
             }
             #[cfg(feature = "zstd")]
             Inner::Zstd(ref mut decoder) => {
-                match futures_util::ready!(Pin::new(&mut *decoder).poll_next(cx)) {
+                match ready!(Pin::new(&mut *decoder).poll_next(cx)) {
                     Some(Ok(bytes)) => Poll::Ready(Some(Ok(Frame::data(bytes.freeze())))),
                     Some(Err(err)) => Poll::Ready(Some(Err(crate::error::decode_io(err)))),
                     None => {
@@ -387,7 +385,7 @@ impl HttpBody for Decoder {
             }
             #[cfg(feature = "deflate")]
             Inner::Deflate(ref mut decoder) => {
-                match futures_util::ready!(Pin::new(&mut *decoder).poll_next(cx)) {
+                match ready!(Pin::new(&mut *decoder).poll_next(cx)) {
                     Some(Ok(bytes)) => Poll::Ready(Some(Ok(Frame::data(bytes.freeze())))),
                     Some(Err(err)) => Poll::Ready(Some(Err(crate::error::decode_io(err)))),
                     None => {
@@ -431,7 +429,7 @@ fn poll_inner_should_be_empty(
     // loop in case of empty frames
     let mut inner = Pin::new(inner);
     loop {
-        match futures_util::ready!(inner.as_mut().poll_next(cx)) {
+        match ready!(inner.as_mut().poll_next(cx)) {
             // ignore any empty frames
             Some(Ok(bytes)) if bytes.is_empty() => continue,
             Some(Ok(_)) => {
@@ -468,17 +466,15 @@ impl Future for Pending {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         use futures_util::StreamExt;
 
-        match futures_util::ready!(Pin::new(&mut self.0).poll_peek(cx)) {
+        match ready!(Pin::new(&mut self.0).poll_peek(cx)) {
             Some(Ok(_)) => {
                 // fallthrough
             }
             Some(Err(_e)) => {
                 // error was just a ref, so we need to really poll to move it
-                return Poll::Ready(Err(futures_util::ready!(
-                    Pin::new(&mut self.0).poll_next(cx)
-                )
-                .expect("just peeked Some")
-                .unwrap_err()));
+                return Poll::Ready(Err(ready!(Pin::new(&mut self.0).poll_next(cx))
+                    .expect("just peeked Some")
+                    .unwrap_err()));
             }
             None => return Poll::Ready(Ok(Inner::PlainText(empty()))),
         };
@@ -537,7 +533,7 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         loop {
-            return match futures_util::ready!(Pin::new(&mut self.0).poll_frame(cx)) {
+            return match ready!(Pin::new(&mut self.0).poll_frame(cx)) {
                 Some(Ok(frame)) => {
                     // skip non-data frames
                     if let Ok(buf) = frame.into_data() {

--- a/src/client/websocket/mod.rs
+++ b/src/client/websocket/mod.rs
@@ -10,7 +10,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     ops::{Deref, DerefMut},
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use crate::{error, Error, IntoUrl, RequestBuilder, Response};
@@ -564,7 +564,7 @@ impl Stream for WebSocket {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
-            match futures_util::ready!(self.inner.poll_next_unpin(cx)) {
+            match ready!(self.inner.poll_next_unpin(cx)) {
                 Some(Ok(msg)) => {
                     if let Some(msg) = Message::from_tungstenite(msg) {
                         return Poll::Ready(Some(Ok(msg)));

--- a/src/util/client/connect/dns.rs
+++ b/src/util/client/connect/dns.rs
@@ -21,7 +21,7 @@
 //! });
 //! ```
 use std::error::Error;
-use std::future::Future;
+use std::future::{self, Future};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
 use std::pin::Pin;
 use std::str::FromStr;
@@ -298,6 +298,6 @@ pub(super) async fn resolve<R>(resolver: &mut R, name: Name) -> Result<R::Addrs,
 where
     R: Resolve,
 {
-    futures_util::future::poll_fn(|cx| resolver.poll_ready(cx)).await?;
+    future::poll_fn(|cx| resolver.poll_ready(cx)).await?;
     resolver.resolve(name).await
 }

--- a/src/util/client/connect/http.rs
+++ b/src/util/client/connect/http.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{self, Poll};
+use std::task::{self, ready, Poll};
 use std::time::Duration;
 
 use futures_util::future::Either;
@@ -461,7 +461,7 @@ where
     type Future = HttpConnecting<R>;
 
     fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        futures_util::ready!(self.resolver.poll_ready(cx)).map_err(ConnectError::dns)?;
+        ready!(self.resolver.poll_ready(cx)).map_err(ConnectError::dns)?;
         Poll::Ready(Ok(()))
     }
 

--- a/src/util/client/pool.rs
+++ b/src/util/client/pool.rs
@@ -8,11 +8,10 @@ use std::num::NonZero;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::sync::{Arc, Weak};
-use std::task::{self, Poll};
+use std::task::{self, ready, Poll};
 use std::time::{Duration, Instant};
 
 use antidote::Mutex;
-use futures_util::ready;
 use log::{debug, trace};
 use lru::LruCache;
 

--- a/src/util/service/oneshot.rs
+++ b/src/util/service/oneshot.rs
@@ -1,8 +1,7 @@
-use futures_util::ready;
 use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use tower_service::Service;
 
 // Vendored from tower::util to reduce dependencies, the code is small enough.


### PR DESCRIPTION
This pull request focuses on replacing the `futures_util::ready!` macro with the `std::task::ready!` macro across multiple files to streamline the codebase. The changes span several modules, including `body.rs`, `decoder.rs`, `websocket/mod.rs`, `dns.rs`, `http.rs`, `pool.rs`, and `oneshot.rs`.

### Macro Replacement:

* [`src/client/body.rs`](diffhunk://#diff-7038768ab4f60be7f7e1ee48b88ee66eeaa34e614f87e52d2bb1647f214503e4L4-R4): Replaced `futures_util::ready!` with `std::task::ready!` in various functions and implementations. [[1]](diffhunk://#diff-7038768ab4f60be7f7e1ee48b88ee66eeaa34e614f87e52d2bb1647f214503e4L4-R4) [[2]](diffhunk://#diff-7038768ab4f60be7f7e1ee48b88ee66eeaa34e614f87e52d2bb1647f214503e4L271-R271) [[3]](diffhunk://#diff-7038768ab4f60be7f7e1ee48b88ee66eeaa34e614f87e52d2bb1647f214503e4L326-R326) [[4]](diffhunk://#diff-7038768ab4f60be7f7e1ee48b88ee66eeaa34e614f87e52d2bb1647f214503e4L369-R369) [[5]](diffhunk://#diff-7038768ab4f60be7f7e1ee48b88ee66eeaa34e614f87e52d2bb1647f214503e4L440-R440) [[6]](diffhunk://#diff-7038768ab4f60be7f7e1ee48b88ee66eeaa34e614f87e52d2bb1647f214503e4L476-R476)
* [`src/client/decoder.rs`](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL10-R10): Updated the macro usage in several `impl HttpBody for Decoder` blocks and other functions. [[1]](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL10-R10) [[2]](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL339-R346) [[3]](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL362-R360) [[4]](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL376-R374) [[5]](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL390-R388) [[6]](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL434-R432) [[7]](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL471-R475) [[8]](diffhunk://#diff-c02168a813af3a9125a5f826399a91e1140bf195d7806595ca73ce28a4f5a61bL540-R536)
* [`src/client/websocket/mod.rs`](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL13-R13): Changed the macro in the `impl Stream for WebSocket`. [[1]](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL13-R13) [[2]](diffhunk://#diff-9c330e1b4c96db3a94063fa8051a4e5c011658571686e814f740892635a92f6fL567-R567)
* [`src/util/client/connect/dns.rs`](diffhunk://#diff-7448001a9474cfa675cf49434f72f320da7a0aed9858cda3fc8ea004eb6b826bL24-R24): Replaced the macro in the `resolve` function. [[1]](diffhunk://#diff-7448001a9474cfa675cf49434f72f320da7a0aed9858cda3fc8ea004eb6b826bL24-R24) [[2]](diffhunk://#diff-7448001a9474cfa675cf49434f72f320da7a0aed9858cda3fc8ea004eb6b826bL301-R301)
* [`src/util/client/connect/http.rs`](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L9-R9): Updated the macro in the `poll_ready` function. [[1]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L9-R9) [[2]](diffhunk://#diff-d107346d32321126c29f9f2f721326c2fe006ceb274b54b9e302aaf60c035993L464-R464)
* [`src/util/client/pool.rs`](diffhunk://#diff-bd4f40bf3f31318e4c639ff7961b0392a40848ae6b378a70293338d81d55fb3fL11-L15): Modified the macro usage in the file.
* [`src/util/service/oneshot.rs`](diffhunk://#diff-88509cc14ecd65e380667edd4c5270ae5dffe97995fd9af0b751948cee9b0141L1-R4): Replaced the macro in the file.