### PR TITLE
feat(websocket): Added `read_buffer_size` optional config

### DIFF
--- a/examples/connect_via_lower_priority_tokio_runtime.rs
+++ b/examples/connect_via_lower_priority_tokio_runtime.rs
@@ -243,7 +243,7 @@ mod background_threadpool {
             // now poll on the receiver end of the oneshot to get the result
             match this.rx.poll(cx) {
                 Poll::Ready(v) => match v {
-                    Ok(v) => Poll::Ready(v.map_err(Into::into)),
+                    Ok(v) => Poll::Ready(v),
                     Err(err) => Poll::Ready(Err(Box::new(err) as BoxError)),
                 },
                 Poll::Pending => Poll::Pending,

--- a/src/client/websocket/mod.rs
+++ b/src/client/websocket/mod.rs
@@ -103,6 +103,12 @@ impl WebSocketRequestBuilder {
         self
     }
 
+    /// Sets the websocket read_buffer_size configuration.
+    pub fn read_buffer_size(mut self, read_buffer_size: usize) -> Self {
+        self.config.read_buffer_size = read_buffer_size;
+        self
+    }
+
     /// Sets the websocket write_buffer_size configuration.
     pub fn write_buffer_size(mut self, write_buffer_size: usize) -> Self {
         self.config.write_buffer_size = write_buffer_size;


### PR DESCRIPTION
This pull request introduces a new method to the `WebSocketRequestBuilder` in the `src/client/websocket/mod.rs` file to allow configuration of the websocket read buffer size.

* Added `read_buffer_size` method to set the websocket read buffer size in `WebSocketRequestBuilder`.