### PR TITLE
build(deps): update boring requirement from 4.15.7 to 4.15.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,9 +113,9 @@ socket2 = { version = "0.5", features = ["all"] }
 lru = { version = "0.13", default-features = false }
 
 ## boring-tls
-boring2 = { version = "4.15.7", features = ["pq-experimental"] }
-boring-sys2 = { version = "4.15.7", features = ["pq-experimental"] }
-tokio-boring2 = { version = "4.15.7", features = ["pq-experimental"] }
+boring2 = { version = "4.15.8", features = ["pq-experimental"] }
+boring-sys2 = { version = "4.15.8", features = ["pq-experimental"] }
+tokio-boring2 = { version = "4.15.8", features = ["pq-experimental"] }
 foreign-types = "0.5.0"
 linked_hash_set = "0.1"
 


### PR DESCRIPTION
See https://github.com/sfackler/rust-openssl/pull/2360 and https://nvd.nist.gov/vuln/detail/CVE-2025-24898. From the rust-openssl PR:
> `SSL_select_next_proto` can return a pointer into either the client or server buffers, but the type signature of the function previously only bound the output buffer to the client buffer. This can result in a UAF in situations where the server slice does not point to a long-lived allocation.

Thanks to Matt Mastracci for reporting this issue.