### PR TITLE
feat(client): Added a clear cookies function

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1689,9 +1689,7 @@ impl ClientRef {
     {
         if let Some(ref cookie_store) = self.inner.cookie_store {
             let mut cookies = cookies.as_ref().iter().peekable();
-            if cookies.peek().is_some() {
-                cookie_store.set_cookies(&mut cookies, url);
-            }
+            cookie_store.set_cookies(&mut cookies, url);
         }
     }
 
@@ -1714,9 +1712,23 @@ impl ClientRef {
     {
         if let Some(ref cookie_store) = self.inner.cookie_store {
             let mut cookies = cookies.as_ref().iter().copied().peekable();
-            if cookies.peek().is_some() {
-                cookie_store.set_cookies(&mut cookies, url);
-            }
+            cookie_store.set_cookies(&mut cookies, url);
+        }
+    }
+
+    /// Clears all cookies from the `CookieStore`.
+    ///
+    /// This method removes all cookies stored in the client's `CookieStore`.
+    /// It can be useful in scenarios where you want to reset the client's state
+    /// or ensure that no cookies are sent with subsequent requests.
+    ///
+    /// # Note
+    ///
+    /// This method requires the `cookies` feature to be enabled.
+    #[cfg(feature = "cookies")]
+    pub fn clear_cookies(&self) {
+        if let Some(ref cookie_store) = self.inner.cookie_store {
+            cookie_store.clear();
         }
     }
 }

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1689,7 +1689,9 @@ impl ClientRef {
     {
         if let Some(ref cookie_store) = self.inner.cookie_store {
             let mut cookies = cookies.as_ref().iter().peekable();
-            cookie_store.set_cookies(&mut cookies, url);
+            if cookies.peek().is_some() {
+                cookie_store.set_cookies(&mut cookies, url);
+            }
         }
     }
 
@@ -1712,7 +1714,9 @@ impl ClientRef {
     {
         if let Some(ref cookie_store) = self.inner.cookie_store {
             let mut cookies = cookies.as_ref().iter().copied().peekable();
-            cookie_store.set_cookies(&mut cookies, url);
+            if cookies.peek().is_some() {
+                cookie_store.set_cookies(&mut cookies, url);
+            }
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new method to clear cookies from the client's `CookieStore` and includes corresponding tests. The most important changes are:

Enhancements to `ClientRef`:

* Added a new method `clear_cookies` to the `ClientRef` implementation, which clears all cookies from the client's `CookieStore`. This method requires the `cookies` feature to be enabled.

Code cleanup:

* Removed redundant checks for empty cookies in the `set_cookies` method of the `ClientRef` implementation. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1692-L1696) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1717-R1732)

Testing:

* Added a new test `clear_cookies` in `tests/cookie.rs` to verify that the `clear_cookies` method correctly clears all cookies from the client's `CookieStore`.