### PR TITLE
feat(client): deprecated `set_cookies_by_ref`

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1522,6 +1522,10 @@ impl Client {
     ///
     /// This method ensures that cookies are only set if at least one cookie
     /// exists in the collection.
+    #[deprecated(
+        since = "2.2.0",
+        note = "Please use `set_cookies` with a collection of `HeaderValue` instead."
+    )]
     #[cfg(feature = "cookies")]
     pub fn set_cookies_by_ref<'a, C>(&self, url: &Url, cookies: C)
     where


### PR DESCRIPTION
This pull request includes a deprecation notice for a method in the `Client` implementation in the `src/client/http.rs` file. The deprecated method is `set_cookies_by_ref`, and users are advised to use the `set_cookies` method with a collection of `HeaderValue` instead.

Deprecation notice:

* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90R1525-R1528): Added a deprecation notice for the `set_cookies_by_ref` method, recommending the use of `set_cookies` with a collection of `HeaderValue` instead.