### PR TITLE
feat(client): Remove cross-origin redirect proxy support

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -160,12 +160,7 @@ impl Policy {
         .inner
     }
 
-    pub(crate) fn remove_sensitive_headers(
-        headers: &mut HeaderMap,
-        next: &Url,
-        previous: &[Url],
-        cross_proxy_auth: bool,
-    ) {
+    pub(crate) fn remove_sensitive_headers(headers: &mut HeaderMap, next: &Url, previous: &[Url]) {
         if let Some(previous) = previous.last() {
             let cross_host = next.host_str() != previous.host_str()
                 || next.port_or_known_default() != previous.port_or_known_default();
@@ -173,9 +168,7 @@ impl Policy {
                 headers.remove(AUTHORIZATION);
                 headers.remove(COOKIE);
                 headers.remove("cookie2");
-                if !cross_proxy_auth {
-                    headers.remove(PROXY_AUTHORIZATION);
-                }
+                headers.remove(PROXY_AUTHORIZATION);
                 headers.remove(WWW_AUTHENTICATE);
             }
         }
@@ -389,41 +382,13 @@ fn test_remove_sensitive_headers() {
     let mut prev = vec![Url::parse("http://initial-domain.com/new_path").unwrap()];
     let mut filtered_headers = headers.clone();
 
-    Policy::remove_sensitive_headers(&mut headers, &next, &prev, false);
+    Policy::remove_sensitive_headers(&mut headers, &next, &prev);
     assert_eq!(headers, filtered_headers);
 
     prev.push(Url::parse("http://new-domain.com/path").unwrap());
     filtered_headers.remove(AUTHORIZATION);
     filtered_headers.remove(COOKIE);
 
-    Policy::remove_sensitive_headers(&mut headers, &next, &prev, false);
-    assert_eq!(headers, filtered_headers);
-}
-
-#[test]
-fn test_proxy_auth_redirect_headers() {
-    use hyper2::header::{HeaderValue, ACCEPT, AUTHORIZATION, COOKIE};
-
-    let mut headers = HeaderMap::new();
-    headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
-    headers.insert(AUTHORIZATION, HeaderValue::from_static("let me in"));
-    headers.insert(
-        PROXY_AUTHORIZATION,
-        HeaderValue::from_static("let me in proxy"),
-    );
-    headers.insert(COOKIE, HeaderValue::from_static("foo=bar"));
-
-    let next = Url::parse("http://initial-domain.com/path").unwrap();
-    let mut prev = vec![Url::parse("http://initial-domain.com/new_path").unwrap()];
-    let mut filtered_headers = headers.clone();
-
-    Policy::remove_sensitive_headers(&mut headers, &next, &prev, true);
-    assert_eq!(headers, filtered_headers);
-
-    prev.push(Url::parse("http://new-domain.com/path").unwrap());
-    filtered_headers.remove(AUTHORIZATION);
-    filtered_headers.remove(COOKIE);
-
-    Policy::remove_sensitive_headers(&mut headers, &next, &prev, true);
+    Policy::remove_sensitive_headers(&mut headers, &next, &prev);
     assert_eq!(headers, filtered_headers);
 }


### PR DESCRIPTION
This pull request involves the removal of the `redirect_with_proxy_auth` feature from the HTTP client in the `src/client/http.rs` file. The changes simplify the codebase by removing associated configurations, methods, and references to this feature.

Key changes include:

### Removal of `redirect_with_proxy_auth` feature:

* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L107): Removed the `redirect_with_proxy_auth` field from the `Config` and `ClientInner` structs. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L107) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1638)
* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L610-L639): Deleted the `redirect_with_proxy_auth` method from the `ClientBuilder` implementation.
* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L188): Removed references to `redirect_with_proxy_auth` from the `ClientBuilder` and `PendingRequest` implementations. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L188) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L281) [[3]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L2251)

### Update to header removal logic:

* [`src/redirect.rs`](diffhunk://#diff-f9c2a8c37b690ffe48b65bc57bd72784eb946d600d3b00cd5073259a7e32f001L163-L178): Simplified the `remove_sensitive_headers` method by removing the `cross_proxy_auth` parameter and its associated logic.

### Tests update:

* [`src/redirect.rs`](diffhunk://#diff-f9c2a8c37b690ffe48b65bc57bd72784eb946d600d3b00cd5073259a7e32f001L392-R392): Updated the `test_remove_sensitive_headers` test to reflect the changes in the `remove_sensitive_headers` method and removed the `test_proxy_auth_redirect_headers` test.