### PR TITLE
docs: update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An ergonomic all-in-one HTTP client for browser emulation with TLS, JA3/JA4, and
 - Header Order
 - Redirect Policy
 - Cookie Store
-- HTTP Proxies
+- Rotating Proxies
 - WebSocket Upgrade
 - HTTPS via BoringSSL
 - Perfectly Chrome, Safari, and Firefox
@@ -28,8 +28,8 @@ This asynchronous example utilizes [Tokio](https://tokio.rs) with optional featu
 ```toml
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-rquest = "3.0.1-rc1"
-rquest_util = "0.2.0-rc1"
+rquest = "3.0.1-rc3"
+rquest-util = "0.2.0-rc1"
 ```
 
 And then the code:
@@ -42,7 +42,7 @@ use rquest_util::Emulation;
 async fn main() -> Result<(), rquest::Error> {
     // Build a client
     let client = Client::builder()
-        .emulation(Emulation::Firefox133)
+        .emulation(Emulation::Firefox135)
         .build()?;
 
     // Use the API you're already familiar with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,14 +211,14 @@
 //! ```bash
 //! export https_proxy=socks5://127.0.0.1:1086
 //! ```
-//! 
+//!
 //! * `http://` is the scheme for http proxy
 //! * `https://` is the scheme for https proxy
 //! * `socks4://` is the scheme for socks4 proxy
 //! * `socks4a://` is the scheme for socks4a proxy
 //! * `socks5://` is the scheme for socks5 proxy
 //! * `socks5h://` is the scheme for socks5h proxy
-//! 
+//!  
 //! ## TLS
 //!
 //! By default, clients will utilize BoringSSL transport layer security to connect to HTTPS targets.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! async fn main() -> Result<(), rquest::Error> {
 //!     // Build a client
 //!     let client = Client::builder()
-//!         .emulation(Emulation::Firefox133)
+//!         .emulation(Emulation::Firefox135)
 //!         .build()?;
 //!
 //!     // Use the API you're already familiar with
@@ -57,7 +57,7 @@
 //! async fn main() -> Result<(), rquest::Error> {
 //!     // Build a client
 //!     let websocket = Client::builder()
-//!         .emulation(Emulation::Firefox133)
+//!         .emulation(Emulation::Firefox135)
 //!         .build()?
 //!         .websocket("wss://echo.websocket.org")
 //!         .send()
@@ -211,6 +211,14 @@
 //! ```bash
 //! export https_proxy=socks5://127.0.0.1:1086
 //! ```
+//! 
+//! * `http://` is the scheme for http proxy
+//! * `https://` is the scheme for https proxy
+//! * `socks4://` is the scheme for socks4 proxy
+//! * `socks4a://` is the scheme for socks4a proxy
+//! * `socks5://` is the scheme for socks5 proxy
+//! * `socks5h://` is the scheme for socks5h proxy
+//! 
 //! ## TLS
 //!
 //! By default, clients will utilize BoringSSL transport layer security to connect to HTTPS targets.
@@ -223,8 +231,10 @@
 //! The following are a list of [Cargo features][cargo-features] that can be
 //! enabled or disabled:
 //!
+//! - **full**: Enables all optional features.
 //! - **websocket**: Provides websocket support.
 //! - **cookies**: Provides cookie session support.
+//! - **cookies-abstract**: Provides abstract cookie session support.
 //! - **gzip**: Provides response body gzip decompression.
 //! - **brotli**: Provides response body brotli decompression.
 //! - **zstd**: Provides response body zstd decompression.
@@ -235,6 +245,11 @@
 //! - **socks**: Provides SOCKS5 proxy support.
 //! - **hickory-dns**: Enables a hickory-dns async resolver instead of default
 //!   threadpool using `getaddrinfo`.
+//! - **native-roots**: Use the native system root certificate store.
+//! - **webpki-roots**: Use the webpki-roots crate for root certificates.
+//! - **apple-network-device-binding**: Use the Apple Network Device Binding
+//! - **http2-tracing**: Enable HTTP/2 tracing.
+//! - **internal_proxy_sys_no_cache**: Use the internal proxy system with no cache.
 //!
 //! [hyper]: http://hyper.rs
 //! [client]: ./struct.Client.html
@@ -244,7 +259,6 @@
 //! [serde]: http://serde.rs
 //! [redirect]: crate::redirect
 //! [Proxy]: ./struct.Proxy.html
-//! [preconfigured]: ./struct.ClientBuilder.html#method.use_preconfigured_tls
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
 #[cfg(feature = "hickory-dns")]
@@ -337,8 +351,14 @@ fn _assert_impls() {
 
     assert_send::<Request>();
     assert_send::<RequestBuilder>();
+    #[cfg(feature = "websocket")]
+    assert_send::<WebSocketRequestBuilder>();
 
     assert_send::<Response>();
+    #[cfg(feature = "websocket")]
+    assert_send::<WebSocketResponse>();
+    #[cfg(feature = "websocket")]
+    assert_send::<WebSocket>();
 
     assert_send::<Error>();
     assert_sync::<Error>();


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and the `src/lib.rs` file, focusing on dependency updates, feature enhancements, and documentation improvements.

### Dependency Updates:
* Updated `rquest` to version `3.0.1-rc3` and corrected the name of `rquest-util` in `README.md` (`[README.mdL31-R32](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R32)`).

### Feature Enhancements:
* Changed the emulation version from `Firefox133` to `Firefox135` in both `README.md` and `src/lib.rs` (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45)`, `[[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L36-R36)`, `[[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L60-R60)`).

### Documentation Improvements:
* Replaced "HTTP Proxies" with "Rotating Proxies" in the feature list (`README.md`) (`[README.mdL19-R19](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19)`).
* Added detailed proxy scheme descriptions in `src/lib.rs` (`[src/lib.rsR214-R221](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R214-R221)`).
* Updated the list of Cargo features in `src/lib.rs` to include new features such as `cookies-abstract`, `native-roots`, `webpki-roots`, `apple-network-device-binding`, `http2-tracing`, and `internal_proxy_sys_no_cache` (`[[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R234-R237)`, `[[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R248-R252)`).
* Removed an outdated reference to `use_preconfigured_tls` in `src/lib.rs` (`[src/lib.rsL247](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L247)`).

### Code Enhancements:
* Added assertions for `WebSocketRequestBuilder`, `WebSocketResponse`, and `WebSocket` to ensure they implement the `Send` trait when the `websocket` feature is enabled (`[src/lib.rsR354-R361](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R354-R361)`).