### PR TITLE
refactor(cookie): redesign cookie store API signature

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1445,6 +1445,21 @@ impl Client {
         }
     }
 
+    /// Inserts a cookie into the `CookieStore` for the specified URL.
+    ///
+    /// # Note
+    ///
+    /// This method requires the `cookies` feature to be enabled.
+    #[cfg(any(feature = "cookies", feature = "cookies-abstract"))]
+    pub fn insert_cookie<C>(&self, url: &Url, cookie: C)
+    where
+        C: AsRef<HeaderValue>,
+    {
+        if let Some(ref cookie_store) = self.inner.load().cookie_store {
+            cookie_store.insert(url, cookie.as_ref());
+        }
+    }
+
     /// Removes a cookie from the `CookieStore` for the specified URL.
     ///
     /// This method deletes a cookie with the given name from the client's `CookieStore`
@@ -1463,7 +1478,7 @@ impl Client {
     #[cfg(any(feature = "cookies", feature = "cookies-abstract"))]
     pub fn remove_cookie(&self, url: &Url, name: &str) {
         if let Some(ref cookie_store) = self.inner.load().cookie_store {
-            cookie_store.remove_cookie(url, name);
+            cookie_store.remove(url, name);
         }
     }
 


### PR DESCRIPTION
This pull request introduces several changes to the `Client` and `CookieStore` implementations in the `src/client/http.rs` and `src/cookie.rs` files. The changes primarily focus on adding new methods for cookie management and refactoring existing methods for improved functionality.

### Cookie Management Enhancements:

* Added a new method `insert_cookie` to the `Client` implementation to insert cookies into the `CookieStore` for a specified URL. This method is conditional on the `cookies` or `cookies-abstract` features being enabled.
* Refactored the `remove_cookie` method in the `Client` implementation to use the `remove` method instead of `remove_cookie` in the `CookieStore`.

### Refactoring and New Methods in `CookieStore`:

* Introduced a new method `insert` in the `CookieStore` trait for inserting cookies into the store for a specified URL.
* Refactored the `remove_cookie` method in the `CookieStore` trait to `remove` for better consistency and clarity.
* Implemented the new `insert` method in the `Jar` struct, which is part of the `CookieStore` implementation, to handle cookie insertion.
* Re-added the `remove` method in the `Jar` struct to replace the previously removed `remove_cookie` method, maintaining the functionality of removing cookies by name for a specified URL.