### PR TITLE
feat(client): Add a straightforward method for SSL pinning setup

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1017,6 +1017,73 @@ impl ClientBuilder {
         self
     }
 
+    /// Configures SSL certificate pinning for the client.
+    ///
+    /// This method allows you to specify a set of PEM-encoded certificates that the client
+    /// will pin to, ensuring that only these certificates are trusted during SSL/TLS connections.
+    /// This provides an additional layer of security by preventing man-in-the-middle (MITM) attacks,
+    /// even if a malicious certificate is issued by a trusted Certificate Authority (CA).
+    ///
+    /// # Parameters
+    ///
+    /// - `certs`: An iterator of PEM-encoded certificates. Each certificate should be provided
+    ///   as a byte slice (`&[u8]`).
+    ///
+    /// # How It Works
+    ///
+    /// SSL pinning ensures that the client only trusts the specified certificates, bypassing
+    /// the system's default root certificate store. This is particularly useful in scenarios
+    /// where:
+    /// - You want to trust a specific self-signed certificate.
+    /// - You want to restrict trust to a specific server's certificate, even if it is signed
+    ///   by a public CA.
+    ///
+    /// The certificates provided to this method can be:
+    /// - **Self-signed certificates**: Useful for internal systems or development environments.
+    /// - **Server certificates**: The exact certificate presented by the server during the TLS handshake.
+    /// - **Intermediate certificates**: Certificates in the chain between the server and the root CA.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rquest::Client;
+    ///
+    /// let client = Client::builder()
+    ///     .ssl_pinning(vec![
+    ///         include_bytes!("certs/server_cert.pem"),
+    ///         include_bytes!("certs/intermediate_cert.pem"),
+    ///     ])
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// # Notes
+    ///
+    /// - If the server's certificate does not match any of the pinned certificates, the connection
+    ///   will fail.
+    /// - Ensure that the provided certificates are up-to-date. If the server's certificate changes
+    ///   (e.g., due to expiration), you will need to update the pinned certificates in your client.
+    /// - This method does not support public key pinning. If you need to pin to a public key instead
+    ///   of a certificate, you will need to implement custom logic.
+    ///
+    /// # Errors
+    ///
+    /// If the provided certificates are invalid or cannot be parsed, this method will set an error
+    /// in the builder, and the `build` method will return an error.
+    pub fn ssl_pinning<C>(mut self, certs: C) -> ClientBuilder
+    where
+        C: IntoIterator,
+        C::Item: AsRef<[u8]>,
+    {
+        match CertStore::from_pem_certs(certs) {
+            Ok(store) => {
+                self.config.cert_store = Some(Cow::Owned(store));
+            }
+            Err(err) => self.config.error = Some(err),
+        }
+        self
+    }
+
     /// Controls the use of certificate validation.
     ///
     /// Defaults to `true`.

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1017,7 +1017,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Configures SSL certificate pinning for the client.
+    /// Configures SSL/TLS certificate pinning for the client.
     ///
     /// This method allows you to specify a set of PEM-encoded certificates that the client
     /// will pin to, ensuring that only these certificates are trusted during SSL/TLS connections.

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -198,3 +198,14 @@ async fn test_aes_hw_override() -> Result<(), rquest::Error> {
     assert!(!text.contains("ChaCha20Poly1305"));
     Ok(())
 }
+
+#[tokio::test]
+async fn ssl_pinning() -> Result<(), rquest::Error> {
+    let client = rquest::Client::builder()
+        .ssl_pinning([include_bytes!("certs/badssl.pem")])
+        .build()?;
+
+    let resp = client.get("https://self-signed.badssl.com/").send().await?;
+    assert!(resp.status().is_success());
+    Ok(())
+}


### PR DESCRIPTION
close: https://github.com/0x676e67/rquest/issues/555