### PR TITLE
build(deps): pin `tokio-tungstenite` to version `0.26.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ tokio-util = { version = "0.7.0", default-features = false, features = ["codec",
 tokio-socks = { version = "0.5.2", optional = true }
 
 ## websocket
-tokio-tungstenite = { version = "0.26.0", default-features = false, features = ["handshake"], optional = true }
+tokio-tungstenite = { version = "0.26.2", default-features = false, features = ["handshake"], optional = true }
 
 ## hickory-dns
 hickory-resolver = { version = "0.25", optional = true }


### PR DESCRIPTION
fix: Cargo.lock v0.26.1

```bash
error[E0599]: no function or associated item named `from_bytes_unchecked` found for struct `Utf8Bytes` in the current scope
  --> src/client/websocket/message.rs:25:38
   |
25 | ...Utf8Bytes::from_bytes_unchecked(bytes) })
   |               ^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `Utf8Bytes`
   |
   = note: the full type name has been written to '/Users/gngpp/VSCode/rquest/target/debug/deps/rquest-3953d825e1554b74.long-type-8370843427114286319.txt'
   = note: consider using `--verbose` to print the full type name to the console
note: if you're trying to build a new `tokio_tungstenite::tungstenite::Utf8Bytes`, consider using `tokio_tungstenite::tungstenite::Utf8Bytes::from_static` which returns `tokio_tungstenite::tungstenite::Utf8Bytes`
  --> /Users/gngpp/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tungstenite-0.26.1/src/protocol/frame/utf8.rs:12:5
   |
12 |     pub const fn from_static(str: &'static str) -> Sel...
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `rquest` (lib) due to 1 previous error
FAIL: 101
```