### PR TITLE
fix(client): Adapt sorting for duplicate headers such as cookies

### DIFF
--- a/src/util/client/request.rs
+++ b/src/util/client/request.rs
@@ -320,16 +320,17 @@ fn sort_headers(headers: &mut HeaderMap, headers_order: &[HeaderName]) {
     let mut sorted_headers = HeaderMap::with_capacity(headers.keys_len());
 
     // First insert headers in the specified order
-    for key in headers_order {
-        if let Some(value) = headers.remove(key) {
-            sorted_headers.insert(key.clone(), value);
+    for name in headers_order {
+        for value in headers.get_all(name) {
+            sorted_headers.append(name.clone(), value.clone());
         }
+        headers.remove(name);
     }
 
     // Then insert any remaining headers that were not ordered
     for (key, value) in headers.drain() {
         if let Some(key) = key {
-            sorted_headers.insert(key, value);
+            sorted_headers.append(key, value);
         }
     }
 

--- a/tests/client_update.rs
+++ b/tests/client_update.rs
@@ -1,10 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 mod support;
 
-use http::{
-    HeaderMap,
-    header::{AUTHORIZATION, CACHE_CONTROL, REFERER},
-};
+use http::header::{AUTHORIZATION, CACHE_CONTROL, REFERER};
 use http_body_util::BodyExt;
 use rquest::{CertStore, EmulationProvider, TlsConfig};
 use support::server;
@@ -69,7 +66,7 @@ async fn update_headers() {
 }
 
 #[tokio::test]
-async fn test_headers_order_and_requests() {
+async fn test_headers_order_with_client_update() {
     use http::{HeaderName, HeaderValue};
     use rquest::Client;
     use rquest::header::{ACCEPT, CONTENT_TYPE, USER_AGENT};
@@ -83,6 +80,8 @@ async fn test_headers_order_and_requests() {
             ("content-type", "application/json"),
             ("authorization", "Bearer test-token"),
             ("referer", "https://example.com"),
+            ("cookie", "cookie1=cookie1"),
+            ("cookie", "cookie2=cookie2"),
             ("cache-control", "no-cache"),
         ];
 
@@ -107,29 +106,29 @@ async fn test_headers_order_and_requests() {
 
     let url = format!("http://{}/test", server.addr());
 
-    let client = Client::builder()
-        .no_proxy()
-        .default_headers({
-            let mut headers = HeaderMap::new();
+    let client = Client::builder().no_proxy().build().unwrap();
+
+    client
+        .update()
+        .headers(|headers| {
+            headers.clear();
             headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
             headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
             headers.insert(USER_AGENT, HeaderValue::from_static("my-test-client"));
             headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer test-token"));
             headers.insert(REFERER, HeaderValue::from_static("https://example.com"));
+            headers.append("cookie", HeaderValue::from_static("cookie1=cookie1"));
+            headers.append("cookie", HeaderValue::from_static("cookie2=cookie2"));
             headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
-            headers
         })
-        .build()
-        .unwrap();
-
-    client
-        .update()
         .headers_order(vec![
             HeaderName::from_static("user-agent"),
             HeaderName::from_static("accept"),
             HeaderName::from_static("content-type"),
             HeaderName::from_static("authorization"),
             HeaderName::from_static("referer"),
+            HeaderName::from_static("cookie"),
+            HeaderName::from_static("cookie"),
             HeaderName::from_static("cache-control"),
         ])
         .apply()

--- a/tests/client_update.rs
+++ b/tests/client_update.rs
@@ -77,11 +77,11 @@ async fn test_headers_order_with_client_update() {
         let expected_headers = vec![
             ("user-agent", "my-test-client"),
             ("accept", "*/*"),
+            ("cookie", "cookie1=cookie1"),
+            ("cookie", "cookie2=cookie2"),
             ("content-type", "application/json"),
             ("authorization", "Bearer test-token"),
             ("referer", "https://example.com"),
-            ("cookie", "cookie1=cookie1"),
-            ("cookie", "cookie2=cookie2"),
             ("cache-control", "no-cache"),
         ];
 
@@ -117,18 +117,18 @@ async fn test_headers_order_with_client_update() {
             headers.insert(USER_AGENT, HeaderValue::from_static("my-test-client"));
             headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer test-token"));
             headers.insert(REFERER, HeaderValue::from_static("https://example.com"));
+            headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
             headers.append("cookie", HeaderValue::from_static("cookie1=cookie1"));
             headers.append("cookie", HeaderValue::from_static("cookie2=cookie2"));
-            headers.insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
         })
         .headers_order(vec![
             HeaderName::from_static("user-agent"),
             HeaderName::from_static("accept"),
+            HeaderName::from_static("cookie"),
+            HeaderName::from_static("cookie"),
             HeaderName::from_static("content-type"),
             HeaderName::from_static("authorization"),
             HeaderName::from_static("referer"),
-            HeaderName::from_static("cookie"),
-            HeaderName::from_static("cookie"),
             HeaderName::from_static("cache-control"),
         ])
         .apply()


### PR DESCRIPTION
For cookies, if you want to keep the order, then you can only insert the cookies in order. There is no way to specify sorting for a value.