### PR TITLE
feat(request): optionally allow compression in request

### DIFF
--- a/tests/brotli.rs
+++ b/tests/brotli.rs
@@ -360,3 +360,25 @@ async fn test_chunked_fragmented_response_with_extra_bytes() {
     assert!(err.is_decode());
     assert!(start.elapsed() >= DELAY_BETWEEN_RESPONSE_PARTS - DELAY_MARGIN);
 }
+
+#[tokio::test]
+async fn disable_compression_request() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |req| {
+        assert_eq!(req.headers().get("accept-encoding"), None);
+        async { http::Response::default() }
+    });
+
+    let url = format!("http://{}/compress", server.addr());
+
+    let res = rquest::Client::new()
+        .get(&url)
+        .allow_compression(false)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), rquest::StatusCode::OK);
+}

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -365,3 +365,25 @@ async fn test_chunked_fragmented_response_with_extra_bytes() {
     assert!(err.is_decode());
     assert!(start.elapsed() >= DELAY_BETWEEN_RESPONSE_PARTS - DELAY_MARGIN);
 }
+
+#[tokio::test]
+async fn disable_compression_request() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |req| {
+        assert_eq!(req.headers().get("accept-encoding"), None);
+        async { http::Response::default() }
+    });
+
+    let url = format!("http://{}/compress", server.addr());
+
+    let res = rquest::Client::new()
+        .get(&url)
+        .allow_compression(false)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), rquest::StatusCode::OK);
+}

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -366,3 +366,25 @@ async fn test_chunked_fragmented_response_with_extra_bytes() {
     assert!(err.is_decode());
     assert!(start.elapsed() >= DELAY_BETWEEN_RESPONSE_PARTS - DELAY_MARGIN);
 }
+
+#[tokio::test]
+async fn disable_compression_request() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |req| {
+        assert_eq!(req.headers().get("accept-encoding"), None);
+        async { http::Response::default() }
+    });
+
+    let url = format!("http://{}/compress", server.addr());
+
+    let res = rquest::Client::new()
+        .get(&url)
+        .allow_compression(false)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), rquest::StatusCode::OK);
+}

--- a/tests/zstd.rs
+++ b/tests/zstd.rs
@@ -571,3 +571,25 @@ async fn test_connection_reuse_with_chunked_fragmented_multiple_frames_in_one_ch
         peer_addrs
     );
 }
+
+#[tokio::test]
+async fn disable_compression_request() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |req| {
+        assert_eq!(req.headers().get("accept-encoding"), None);
+        async { http::Response::default() }
+    });
+
+    let url = format!("http://{}/compress", server.addr());
+
+    let res = rquest::Client::new()
+        .get(&url)
+        .allow_compression(false)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), rquest::StatusCode::OK);
+}


### PR DESCRIPTION
This pull request includes changes to the `src/client/http.rs` and `src/client/request.rs` files to add support for allowing compression in HTTP requests. The most important changes include the introduction of a new `allow_compression` field in the `Request` struct, modifications to the `Client` implementation to handle compression headers, and the addition of helper functions to manage headers related to compression.

### Support for Allowing Compression:

* [`src/client/request.rs`](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R30): Introduced a new `allow_compression` field in the `Request` struct and added methods to get and set this field. This field is used to determine if the request should announce support for compression. [[1]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R30) [[2]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R57-R62) [[3]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R110-R121) [[4]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R196-R204) [[5]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R223) [[6]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R236) [[7]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R537-R553) [[8]](diffhunk://#diff-aef10c34afeb6a03726464ce7663a34aa00b5a567bd732ca4847aa9d5a2d6c56R877-R882)

### Handling Compression Headers:

* [`src/client/http.rs`](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90R1415-R1420): Modified the `Client` implementation to add the `allow_compression` parameter and handle compression headers accordingly. Added a new helper function `add_accpet_encoding_header` to manage the `Accept-Encoding` header based on the `allow_compression` field. [[1]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90R1415-R1420) [[2]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L1443-R1470) [[3]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L2326-R2324) [[4]](diffhunk://#diff-5a9090205b95168aa13d30e00f2d23d2e5f2cb231e195f4a56b1775bd6118b90L2411-R2437)