### PR TITLE
feat(tls): add API to set list of stable curves

### DIFF
--- a/examples/emulation_firefox.rs
+++ b/examples/emulation_firefox.rs
@@ -1,7 +1,7 @@
 use http::{HeaderMap, HeaderName, HeaderValue, header};
 use rquest::{
     AlpnProtos, AlpsProtos, CertCompressionAlgorithm, ExtensionType, Http1Builder, Http1Config,
-    Http2Builder, SslCurve, TlsConfig, TlsVersion,
+    Http2Builder, TlsConfig, TlsVersion,
 };
 use rquest::{Client, EmulationProvider};
 use rquest::{Http2Config, PseudoOrder::*, SettingsOrder::*};
@@ -15,14 +15,15 @@ macro_rules! join {
     };
 }
 
-const CURVES: &[SslCurve] = &[
-    SslCurve::X25519,
-    SslCurve::SECP256R1,
-    SslCurve::SECP384R1,
-    SslCurve::SECP521R1,
-    SslCurve::FFDHE2048,
-    SslCurve::FFDHE3072,
-];
+const CURVES_LIST: &str = join!(
+    ":",
+    "X25519",
+    "P-256",
+    "P-384",
+    "P-521",
+    "ffdhe2048",
+    "ffdhe3072"
+);
 
 const CIPHER_LIST: &str = join!(
     ":",
@@ -124,7 +125,7 @@ async fn main() -> Result<(), rquest::Error> {
 
     // TLS config
     let tls = TlsConfig::builder()
-        .curves(CURVES)
+        .curves_list(CURVES_LIST)
         .cipher_list(CIPHER_LIST)
         .sigalgs_list(SIGALGS_LIST)
         .delegated_credentials(DELEGATED_CREDENTIALS)

--- a/examples/emulation_twitter.rs
+++ b/examples/emulation_twitter.rs
@@ -1,5 +1,5 @@
 use http::{HeaderMap, HeaderName, HeaderValue, header};
-use rquest::{AlpnProtos, SslCurve, TlsConfig, TlsVersion};
+use rquest::{AlpnProtos, TlsConfig, TlsVersion};
 use rquest::{Client, EmulationProvider};
 use rquest::{Http2Config, PseudoOrder::*};
 
@@ -11,7 +11,7 @@ macro_rules! join {
     };
 }
 
-const CURVES: &[SslCurve] = &[SslCurve::X25519, SslCurve::SECP256R1, SslCurve::SECP384R1];
+const CURVES_LIST: &str = join!(":", "X25519", "P-256", "P-384");
 
 const CIPHER_LIST: &str = join!(
     ":",
@@ -55,7 +55,7 @@ async fn main() -> Result<(), rquest::Error> {
 
     // TLS config
     let tls = TlsConfig::builder()
-        .curves(CURVES)
+        .curves_list(CURVES_LIST)
         .cipher_list(CIPHER_LIST)
         .sigalgs_list(SIGALGS_LIST)
         .alpn_protos(AlpnProtos::ALL)

--- a/src/tls/config.rs
+++ b/src/tls/config.rs
@@ -39,8 +39,9 @@ pub struct TlsConfig {
     pub(crate) psk_dhe_ke: bool,
     pub(crate) renegotiation: bool,
     pub(crate) delegated_credentials: Option<Cow<'static, str>>,
-    pub(crate) cipher_list: Option<Cow<'static, str>>,
     pub(crate) curves: Option<Cow<'static, [SslCurve]>>,
+    pub(crate) curves_list: Option<Cow<'static, str>>,
+    pub(crate) cipher_list: Option<Cow<'static, str>>,
     pub(crate) sigalgs_list: Option<Cow<'static, str>>,
     pub(crate) cert_compression_algorithm: Option<Cow<'static, [CertCompressionAlgorithm]>>,
     pub(crate) extension_permutation_indices: Option<Cow<'static, [u8]>>,
@@ -75,8 +76,9 @@ impl Default for TlsConfig {
             psk_dhe_ke: true,
             renegotiation: true,
             delegated_credentials: None,
-            cipher_list: None,
             curves: None,
+            curves_list: None,
+            cipher_list: None,
             sigalgs_list: None,
             cert_compression_algorithm: None,
             extension_permutation_indices: None,
@@ -258,21 +260,30 @@ impl TlsConfigBuilder {
         self
     }
 
-    /// Sets the cipher list.
-    pub fn cipher_list<T>(mut self, ciphers: T) -> Self
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        self.config.cipher_list = Some(ciphers.into());
-        self
-    }
-
     /// Sets the supported curves.
     pub fn curves<T>(mut self, curves: T) -> Self
     where
         T: Into<Cow<'static, [SslCurve]>>,
     {
         self.config.curves = Some(curves.into());
+        self
+    }
+
+    /// Sets the supported curves list.
+    pub fn curves_list<T>(mut self, curves: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.config.curves_list = Some(curves.into());
+        self
+    }
+
+    /// Sets the cipher list.
+    pub fn cipher_list<T>(mut self, ciphers: T) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        self.config.cipher_list = Some(ciphers.into());
         self
     }
 

--- a/src/tls/conn/boring.rs
+++ b/src/tls/conn/boring.rs
@@ -185,6 +185,10 @@ impl TlsConnector {
             connector.set_curves(curves)?;
         }
 
+        if let Some(curves_list) = config.curves_list.as_deref() {
+            connector.set_curves_list(curves_list)?;
+        }
+
         if let Some(sigalgs_list) = config.sigalgs_list.as_deref() {
             connector.set_sigalgs_list(sigalgs_list)?;
         }

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
-use rquest::{AlpsProtos, Client, EmulationProvider, TlsInfo, TlsVersion};
-use rquest::{SslCurve, TlsConfig};
+use rquest::{AlpsProtos, Client, EmulationProvider, TlsConfig, TlsInfo, TlsVersion};
 
 macro_rules! join {
     ($sep:expr, $first:expr $(, $rest:expr)*) => {
@@ -45,27 +44,27 @@ async fn test_badssl_self_signed() {
 
     assert!(!text.is_empty());
 }
-
-const CURVES: &[SslCurve] = &[
-    SslCurve::X25519,
-    SslCurve::SECP256R1,
-    SslCurve::SECP384R1,
-    SslCurve::SECP521R1,
-    SslCurve::FFDHE2048,
-    SslCurve::FFDHE3072,
-];
+const CURVES_LIST: &str = join!(
+    ":",
+    "X25519",
+    "P-256",
+    "P-384",
+    "P-521",
+    "ffdhe2048",
+    "ffdhe3072"
+);
 
 #[tokio::test]
 async fn test_3des_support() -> Result<(), rquest::Error> {
     let emulation = EmulationProvider::builder()
         .tls_config(
             TlsConfig::builder()
-                .curves(CURVES)
                 .cipher_list(join!(
                     ":",
                     "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
                     "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA"
                 ))
+                .curves_list(CURVES_LIST)
                 .build(),
         )
         .build();
@@ -94,7 +93,6 @@ async fn test_firefox_7x_100_cipher() -> Result<(), rquest::Error> {
     let emulation = EmulationProvider::builder()
         .tls_config(
             TlsConfig::builder()
-                .curves(CURVES)
                 .cipher_list(join!(
                     ":",
                     "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
@@ -102,6 +100,7 @@ async fn test_firefox_7x_100_cipher() -> Result<(), rquest::Error> {
                     "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
                     "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"
                 ))
+                .curves_list(CURVES_LIST)
                 .build(),
         )
         .build();


### PR DESCRIPTION
the boringssl `set_curves_list()` has been the much more stable API overtime. With previous builds of boringSSL we've had to deal with naming changes that cause set_curves() API to not compile.